### PR TITLE
[Draft] Add support for associated types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ nightly-tests = []
 [dependencies]
 unimock_macros = { path = "unimock_macros", version = "0.4.8" }
 once_cell = "1"
+ghost = "0.1.7"
 pretty_assertions = { version = "1.3", optional = true }
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -676,8 +676,34 @@ impl Unimock {
 }
 
 impl<Assoc> Unimock<Assoc> {
-    /// TODO
-    pub fn new_with_assoc(setup: impl Clause) -> Self {
+    /// Construct a unimock instance for mocking a trait with associated types.
+    ///
+    /// Useful only for traits with methods, as it is requires you to specify
+    /// concrete types on a method, as shown in the example below
+    ///
+    /// # Example
+    /// ```rust
+    /// # use unimock::*;
+    /// #[unimock(api=AssocMock)]
+    /// trait HasAssociatedTypes {
+    ///     type Input;
+    ///     type Output;
+    ///
+    ///     fn exec(&self, inp: Self::Input) -> Option<Self::Output>;
+    /// }
+    ///
+    /// let u = Unimock::with_assoc(
+    ///     AssocMock::exec::<i32, f64>
+    ///         .each_call(matching!(42))
+    ///         .returns(42.0)
+    /// );
+    ///
+    /// assert_eq!(Some(42.0), u.exec(42));
+    ///
+    /// ```
+    /// Its also reasonable to create one unimock instance for one trait unless
+    /// traits share a type used in place of associated type.
+    pub fn with_assoc(setup: impl Clause) -> Self {
         Self::from_assembler(
             assemble::MockAssembler::try_from_clause(setup),
             FallbackMode::Error,

--- a/src/macro_api.rs
+++ b/src/macro_api.rs
@@ -4,6 +4,8 @@ use crate::mismatch::{Mismatch, MismatchKind};
 use crate::output::Output;
 use crate::{call_pattern::MatchingFn, call_pattern::MatchingFnDebug, *};
 
+pub use ::ghost::phantom;
+
 /// The evaluation of a [MockFn].
 ///
 /// Used to tell trait implementations whether to do perform their own evaluation of a call.
@@ -19,7 +21,10 @@ pub enum Evaluation<'u, 'i, F: MockFn> {
 impl<'u, 'i, F: MockFn> Evaluation<'u, 'i, F> {
     /// Unwrap the `Evaluated` variant, or panic.
     /// The unimock instance must be passed in order to register that an eventual panic happened.
-    pub fn unwrap(self, unimock: &Unimock) -> <F::Output<'u> as Output<'u, F::Response>>::Type {
+    pub fn unwrap<T>(
+        self,
+        unimock: &Unimock<T>,
+    ) -> <F::Output<'u> as Output<'u, F::Response>>::Type {
         match self {
             Self::Evaluated(output) => output,
             Self::Skipped(_) => panic!(
@@ -206,7 +211,7 @@ impl MismatchReporter {
 
 /// Evaluate a [MockFn] given some inputs, to produce its output.
 #[track_caller]
-pub fn eval<'u, 'i, F>(unimock: &'u Unimock, inputs: F::Inputs<'i>) -> Evaluation<'u, 'i, F>
+pub fn eval<'u, 'i, F, T>(unimock: &'u Unimock<T>, inputs: F::Inputs<'i>) -> Evaluation<'u, 'i, F>
 where
     F: MockFn + 'static,
 {

--- a/tests/it/assoc_types.rs
+++ b/tests/it/assoc_types.rs
@@ -1,1211 +1,1209 @@
 use async_trait::async_trait;
 use unimock::*;
 
-// #[test]
-// fn noarg_works() {
-//     #[unimock(api=NoArgMock)]
-//     trait NoArg {
-//         type X;
-
-//         fn no_arg(&self) -> Self::X;
-//     }
-
-//     assert_eq!(
-//         1_000_000,
-//         Unimock::with_assoc(
-//             NoArgMock::no_arg::<i32>
-//                 .next_call(matching!())
-//                 .returns(1_000_000)
-//         )
-//         .no_arg()
-//     );
-// }
-
-// #[test]
-// fn owned_output_works() {
-//     #[unimock(api=OwnedMock)]
-//     trait Owned {
-//         type X;
-
-//         fn foo(&self, a: String, b: Self::X) -> Self::X;
-//     }
-
-//     fn takes_owned<O: Owned<X = String>>(
-//         o: &O,
-//         a: impl Into<String>,
-//         b: impl Into<O::X>,
-//     ) -> String {
-//         o.foo(a.into(), b.into())
-//     }
-
-//     assert_eq!(
-//         "ab",
-//         takes_owned(
-//             &Unimock::with_assoc(
-//                 OwnedMock::foo::<String>
-//                     .next_call(matching!(_, _))
-//                     .answers(|(a, b)| format!("{a}{b}"))
-//                     .once()
-//             ),
-//             "a",
-//             "b",
-//         )
-//     );
-//     assert_eq!(
-//         "lol",
-//         takes_owned(
-//             &Unimock::with_assoc(OwnedMock::foo::<String>.stub(|each| {
-//                 each.call(matching!(_, _)).returns("lol");
-//             })),
-//             "a",
-//             "b",
-//         )
-//     );
-//     assert_eq!(
-//         "",
-//         takes_owned(
-//             &Unimock::with_assoc(OwnedMock::foo::<String>.stub(|each| {
-//                 each.call(matching!("a", "b")).returns_default();
-//             })),
-//             "a",
-//             "b",
-//         )
-//     );
-// }
-
-// mod exotic_self_types {
-//     use super::*;
-//     use std::rc::Rc;
-
-//     #[unimock(api=OwnedSelfMock)]
-//     trait OwnedSelf {
-//         type X;
-
-//         fn foo(self);
-//     }
-
-//     #[unimock(api=MutSelfMock)]
-//     trait MutSelf {
-//         type X;
-
-//         fn mut_self(&mut self);
-//     }
-
-//     #[unimock(api=RcSelfMock)]
-//     trait RcSelf {
-//         type X;
-
-//         fn rc_self(self: Rc<Self>);
-//     }
-
-//     #[test]
-//     fn mut_self() {
-//         let mut u: Unimock<AssocType<i32>> = Unimock::with_assoc(
-//             MutSelfMock::mut_self::<i32>
-//                 .each_call(matching!())
-//                 .returns(()),
-//         );
-
-//         u.mut_self();
-//     }
-
-//     #[test]
-//     fn rc_self() {
-//         let deps: Rc<Unimock<AssocType<i32>>> = Rc::new(Unimock::with_assoc(
-//             RcSelfMock::rc_self::<i32>
-//                 .each_call(matching!())
-//                 .returns(()),
-//         ));
-
-//         deps.rc_self();
-//     }
-// }
-
-// mod exotic_methods {
-//     use super::*;
-
-//     #[unimock(api=ProvidedMock)]
-//     trait Provided {
-//         type X: Default;
-
-//         fn not_provided(&self);
-//         fn provided(&self) -> Self::X {
-//             Self::X::default()
-//         }
-//     }
-
-//     #[test]
-//     fn test_provided() {
-//         let deps = Unimock::with_assoc(
-//             ProvidedMock::provided::<i32>
-//                 .each_call(matching!())
-//                 .returns(42),
-//         );
-//         assert_eq!(42, deps.provided());
-//     }
-
-//     #[unimock]
-//     trait SkipStaticProvided {
-//         type X;
-
-//         fn skip1() {}
-//         fn skip2(arg: i32) -> i32 {
-//             arg
-//         }
-//     }
-// }
-
-// mod referenced {
-//     use super::*;
-
-//     #[unimock(api=ReferencedMock)]
-//     trait Referenced {
-//         type X;
-
-//         fn foo(&self, a: &str) -> &str;
-//         fn bar(&self, a: &str, b: &str) -> &str;
-//     }
-
-//     fn takes_referenced<'s, 'x, R: Referenced<X = &'x str>>(r: &'s R, a: R::X) -> &'s str {
-//         r.foo(a)
-//     }
-
-//     #[test]
-//     fn referenced_with_static_return_value_works() {
-//         let u = Unimock::with_assoc(ReferencedMock::foo::<&str>.stub(|each| {
-//             each.call(matching!("a")).returns("answer".to_string());
-//         }));
-//         assert_eq!("answer", takes_referenced(&u, "a",));
-//     }
-
-//     #[test]
-//     fn referenced_with_default_return_value_works() {
-//         let u = Unimock::with_assoc(ReferencedMock::foo::<&str>.stub(|each| {
-//             each.call(matching!("Æ")).panics("Should not be called");
-//             each.call(matching!("a")).returns(String::new());
-//         }));
-//         assert_eq!("", takes_referenced(&u, "a",));
-//     }
-
-//     #[test]
-//     fn referenced_with_static_ref_works() {
-//         let u = Unimock::with_assoc(ReferencedMock::foo::<&str>.stub(|each| {
-//             each.call(matching!("a")).returns("foobar");
-//         }));
-//         assert_eq!("foobar", takes_referenced(&u, "a",));
-//     }
-// }
-
-// mod no_clone_return {
-//     use unimock::*;
-
-//     #[derive(Debug, PartialEq)]
-//     pub struct NoClone(i32);
-
-//     #[unimock(api=FooMock)]
-//     trait Foo {
-//         type X;
-
-//         fn foo(&self) -> Self::X;
-//     }
-
-//     #[test]
-//     fn test_no_clone_return() {
-//         let u = Unimock::with_assoc(
-//             FooMock::foo::<NoClone>
-//                 .some_call(matching!())
-//                 .returns(NoClone(55)),
-//         );
-//         assert_eq!(NoClone(55), u.foo());
-//     }
-// }
-
-// mod each_call_implicitly_clones {
-//     use unimock::*;
-
-//     #[unimock(api=FooMock)]
-//     trait Foo {
-//         type X;
-
-//         fn foo(&self) -> Self::X;
-//     }
-
-//     #[test]
-//     fn each_call_implicit_clone() {
-//         let u = Unimock::with_assoc(FooMock::foo::<i32>.each_call(matching!()).returns(55));
-//         assert_eq!(55, u.foo());
-//         assert_eq!(55, u.foo());
-//     }
-// }
-
-// #[unimock(api=SingleArgMock)]
-// trait SingleArg {
-//     type X;
-
-//     fn method1<'i>(&'i self, a: &'i str) -> &'i Self::X;
-// }
-
-// #[unimock(api=MultiArgMock)]
-// trait MultiArg {
-//     type X;
-
-//     fn method2(&self, a: &str, b: &str) -> &Self::X;
-// }
-
-// #[test]
-// fn test_multiple() {
-//     fn takes_single_multi(
-//         t: &(impl SingleArg<X = &'static str> + MultiArg<X = &'static str>),
-//     ) -> &str {
-//         let tmp = t.method1("b");
-//         t.method2(tmp, tmp)
-//     }
-
-//     let u = Unimock::with_assoc((
-//         SingleArgMock::method1::<&'static str>.stub(|each| {
-//             each.call(matching!("b")).returns("B").once();
-//         }),
-//         MultiArgMock::method2::<&'static str>.stub(|each| {
-//             each.call(matching!("a", _)).panics("should not call this");
-//             each.call(matching!("B", "B")).returns("success").once();
-//         }),
-//     ));
-//     assert_eq!("success", takes_single_multi(&u));
-// }
-
-// mod no_debug {
-//     use super::*;
-
-//     pub enum PrimitiveEnum {
-//         Foo,
-//         Bar,
-//     }
-
-//     #[unimock(api=VeryPrimitiveMock)]
-//     trait VeryPrimitive {
-//         type X;
-
-//         fn primitive(&self, a: PrimitiveEnum, b: Self::X) -> PrimitiveEnum;
-//     }
-
-//     #[test]
-//     fn can_match_a_non_debug_argument() {
-//         match Unimock::with_assoc(VeryPrimitiveMock::primitive::<&str>.stub(|each| {
-//             each.call(matching!(PrimitiveEnum::Bar, _))
-//                 .answers(|_| PrimitiveEnum::Foo);
-//         }))
-//         .primitive(PrimitiveEnum::Bar, "")
-//         {
-//             PrimitiveEnum::Foo => {}
-//             PrimitiveEnum::Bar => panic!(),
-//         }
-//     }
-
-//     #[test]
-//     #[should_panic(expected = "VeryPrimitive::primitive(?, ?): No matching call patterns.")]
-//     fn should_format_non_debug_input_with_a_question_mark() {
-//         Unimock::with_assoc(VeryPrimitiveMock::primitive::<&str>.stub(|each| {
-//             each.call(matching!(PrimitiveEnum::Bar, _))
-//                 .answers(|_| PrimitiveEnum::Foo);
-//         }))
-//         .primitive(PrimitiveEnum::Foo, "");
-//     }
-// }
-
-// #[test]
-// fn should_debug_reference_to_debug_implementing_type() {
-//     #[derive(Debug)]
-//     pub enum DebugEnum {}
-
-//     #[unimock(api=A)]
-//     trait VeryPrimitiveRefZero {
-//         type X;
-
-//         fn primitive_ref(&self, a: DebugEnum) -> DebugEnum;
-//     }
-
-//     #[unimock(api=B)]
-//     trait VeryPrimitiveRefOnce {
-//         type X;
-
-//         fn primitive_ref(&self, a: &DebugEnum) -> DebugEnum;
-//     }
-
-//     #[unimock(api=C)]
-//     trait VeryPrimitiveRefTwice {
-//         type X;
-
-//         fn primitive_ref(&self, a: &&DebugEnum) -> DebugEnum;
-//     }
-// }
-
-// #[test]
-// fn should_be_able_to_borrow_a_returns_value() {
-//     #[derive(Eq, PartialEq, Debug, Clone)]
-//     pub struct Ret<T>(T);
-
-//     #[unimock(api=BorrowsRetMock)]
-//     trait BorrowsRet {
-//         type X;
-
-//         fn borrows_ret(&self) -> &Ret<Self::X>;
-//     }
-
-//     assert_eq!(
-//         &Ret(42),
-//         Unimock::with_assoc(
-//             BorrowsRetMock::borrows_ret::<i32>
-//                 .each_call(matching!())
-//                 .returns(&Ret(42))
-//         )
-//         .borrows_ret()
-//     );
-// }
-
-// #[test]
-// fn various_borrowing() {
-//     #[unimock(api=BorrowingMock)]
-//     trait Borrowing {
-//         type X;
-
-//         fn borrow(&self, input: Self::X) -> &Self::X;
-//         fn borrow_static(&self) -> &'static Self::X;
-//     }
-//     fn get_str<'s, B: Borrowing<X = String>>(t: &'s B, input: &str) -> &'s str {
-//         t.borrow(input.to_string()).as_str()
-//     }
-
-//     let u = Unimock::with_assoc(
-//         BorrowingMock::borrow::<String>
-//             .next_call(matching!(_))
-//             .returns("foo".to_string())
-//             .once(),
-//     );
-//     assert_eq!("foo", get_str(&u, ""));
-//     let u = Unimock::with_assoc(
-//         BorrowingMock::borrow::<String>
-//             .next_call(matching!(_))
-//             .returns("foo".to_string())
-//             .once(),
-//     );
-//     assert_eq!("foo", get_str(&u, ""));
-//     let u = Unimock::with_assoc(
-//         BorrowingMock::borrow::<String>
-//             .next_call(matching!(_))
-//             .answers(|input| format!("{input}{input}"))
-//             .once(),
-//     );
-//     assert_eq!("yoyo", get_str(&u, "yo"));
-//     let u: Unimock<AssocType<String>> = Unimock::with_assoc(
-//         BorrowingMock::borrow_static::<String>
-//             .next_call(matching!(_))
-//             .answers_leaked_ref(|_| format!("yoyoyo"))
-//             .once(),
-//     );
-//     assert_eq!("yoyoyo", u.borrow_static());
-// }
-
-// mod custom_api_module {
-//     use unimock::*;
-
-//     pub struct MyType;
-
-//     #[unimock(api=FakeSingle)]
-//     trait Single {
-//         type X;
-
-//         fn func(&self) -> &Self::X;
-//     }
-
-//     #[test]
-//     #[should_panic(
-//         expected = "Single::func: Expected Single::func(_) at tests/it/assoc_types.rs:427 to match exactly 1 call, but it actually matched no calls.\nMock for Single::func was never called. Dead mocks should be removed."
-//     )]
-//     fn test_without_module() {
-//         Unimock::<AssocType<MyType>>::with_assoc(
-//             FakeSingle::func::<MyType>
-//                 .next_call(matching!(_))
-//                 .returns(MyType)
-//                 .once(),
-//         );
-//     }
-// }
-
-// mod flattened_module {
-//     mod assoc_types {
-//         use unimock::*;
-
-//         #[unimock(api=[Foo, Bar])]
-//         trait WithUnpackedModule {
-//             type X;
-
-//             fn foo(&self, input: String) -> i32;
-//             fn bar(&self);
-//         }
-
-//         #[test]
-//         fn test_unpacked_module() {
-//             let _ = Foo::<i32>.each_call(matching!(_)).returns(33);
-//             let _ = Bar::<()>.each_call(matching!(_)).returns(());
-//         }
-//     }
-
-//     mod generics {
-//         use unimock::*;
-
-//         #[unimock(api=[Foo, Bar])]
-//         trait UnpackedGenerics<T> {
-//             type X;
-
-//             fn foo(&self, input: String) -> T;
-//             fn bar(&self, input: &T);
-//         }
-//     }
-
-//     mod exports {
-//         mod inner {
-//             use unimock::*;
-//             #[unimock(api=[FooMock])]
-//             pub trait Trait {
-//                 type X;
-
-//                 fn foo(&self);
-//             }
-//         }
-
-//         #[test]
-//         fn test_inner() {
-//             use unimock::*;
-//             let _ = inner::FooMock::<i32>.each_call(matching!()).returns(());
-//         }
-//     }
-// }
-
-// #[unimock(api=AsyncMock)]
-// #[async_trait(?Send)]
-// trait Async {
-//     type X;
-
-//     async fn func(&self, arg: Self::X) -> String;
-// }
-
-// #[tokio::test]
-// async fn test_async_trait() {
-//     async fn takes_async<A: Async>(a: &A, arg: A::X) -> String {
-//         a.func(arg).await
-//     }
-
-//     assert_eq!(
-//         "42",
-//         takes_async(
-//             &Unimock::with_assoc(AsyncMock::func::<i32>.stub(|each| {
-//                 each.call(matching!(_)).returns("42");
-//             })),
-//             21
-//         )
-//         .await
-//     );
-// }
-
-// use std::borrow::Cow;
-
-// #[unimock(api=CowBasedMock)]
-// trait CowBased {
-//     type X: ?Sized + ToOwned;
-
-//     fn func(&self, arg: Cow<'static, Self::X>) -> Cow<'static, Self::X>;
-// }
-
-// #[test]
-// fn test_cow() {
-//     fn takes<C: CowBased>(t: &C, arg: Cow<'static, C::X>) -> Cow<'static, C::X> {
-//         t.func(arg)
-//     }
-
-//     assert_eq!(
-//         "output",
-//         takes(
-//             &Unimock::with_assoc(CowBasedMock::func::<str>.stub(|each| {
-//                 each.call(matching! {("input") | ("foo")}).returns("output");
-//             })),
-//             "input".into()
-//         )
-//     );
-// }
-
-// #[test]
-// fn borrow_intricate_lifetimes() {
-//     pub struct I<'s>(std::marker::PhantomData<&'s ()>);
-//     pub struct O<'s>(&'s String);
-
-//     #[unimock(api = IntricateMock)]
-//     trait Intricate {
-//         type X;
-
-//         fn foo<'s, 't>(&'s self, inp: &'t I<'s>) -> &'s O<'t>;
-//     }
-
-//     fn takes_intricate(i: &impl Intricate) {
-//         i.foo(&I(std::marker::PhantomData));
-//     }
-
-//     let u: Unimock<AssocType<()>> = Unimock::with_assoc(
-//         IntricateMock::foo::<()>
-//             .next_call(matching!(I(_)))
-//             .returns(O(Box::leak(Box::new("leaked".to_string())))),
-//     );
-
-//     takes_intricate(&u);
-// }
-
-// #[test]
-// fn clause_helpers() {
-//     #[unimock(api=FooMock)]
-//     trait Foo {
-//         type X;
-
-//         fn m1(&self) -> Self::X;
-//     }
-
-//     #[unimock(api=BarMock)]
-//     trait Bar {
-//         type X;
-
-//         fn m2(&self) -> Self::X;
-//     }
-//     #[unimock(api=BazMock)]
-//     trait Baz {
-//         type X;
-
-//         fn m3(&self) -> Self::X;
-//     }
-
-//     fn setup_foo_bar() -> impl Clause {
-//         (
-//             FooMock::m1::<i32>.some_call(matching!(_)).returns(1),
-//             BarMock::m2::<i32>.each_call(matching!(_)).returns(2),
-//         )
-//     }
-
-//     let deps: Unimock<AssocType<i32>> = Unimock::with_assoc((
-//         setup_foo_bar(),
-//         BazMock::m3::<i32>.each_call(matching!(_)).returns(3),
-//     ));
-//     assert_eq!(6, deps.m1() + deps.m2() + deps.m3());
-// }
-
-// mod responders_in_series {
-//     use super::*;
-
-//     #[unimock(api=SeriesMock)]
-//     trait Series {
-//         type X;
-
-//         fn series(&self) -> Self::X;
-//     }
-
-//     fn clause() -> impl Clause {
-//         SeriesMock::series::<i32>
-//             .each_call(matching!())
-//             .returns(1)
-//             .once()
-//             .then()
-//             .returns(2)
-//             .n_times(2)
-//             .then()
-//             .returns(3)
-//             .at_least_times(1)
-//     }
-
-//     #[test]
-//     fn responder_series_should_work() {
-//         let a = Unimock::with_assoc(clause());
-
-//         assert_eq!(1, a.series());
-//         assert_eq!(2, a.series());
-//         assert_eq!(2, a.series());
-//         // it will continue to return 3:
-//         assert_eq!(3, a.series());
-//         assert_eq!(3, a.series());
-//         assert_eq!(3, a.series());
-//         assert_eq!(3, a.series());
-//     }
-
-//     #[test]
-//     #[should_panic(
-//         expected = "Series::series: Expected Series::series() at tests/it/assoc_types.rs:609 to match at least 4 calls, but it actually matched 2 calls."
-//     )]
-//     fn series_not_fully_generated_should_panic() {
-//         let b = Unimock::with_assoc(clause());
-
-//         assert_eq!(1, b.series());
-//         assert_eq!(2, b.series());
-
-//         // Exact repetition was defined to be 4 (the last responder is not exactly quantified), but it contained a `.then` call so minimum 1.
-//     }
-// }
-
-// #[unimock(api=BorrowStaticMock)]
-// trait BorrowStatic {
-//     type X;
-
-//     fn static_str(&self, arg: Self::X) -> &'static str;
-// }
-
-// #[test]
-// fn borrow_static_should_work_with_returns_static() {
-//     assert_eq!(
-//         "foo",
-//         Unimock::with_assoc(
-//             BorrowStaticMock::static_str::<i32>
-//                 .next_call(matching!(_))
-//                 .returns("foo")
-//         )
-//         .static_str(33)
-//     );
-// }
-
-// mod async_argument_borrowing {
-//     use super::*;
-
-//     #[unimock(api=BorrowParamMock)]
-//     #[async_trait(?Send)]
-//     trait BorrowParam {
-//         type X;
-
-//         async fn borrow_param<'a>(&self, arg: &'a Self::X) -> &'a Self::X;
-//     }
-
-//     #[tokio::test]
-//     async fn test_argument_borrowing() {
-//         let unimock = Unimock::with_assoc(
-//             BorrowParamMock::borrow_param::<&str>
-//                 .each_call(matching!(_))
-//                 .returns(&"foobar"),
-//         );
-
-//         assert_eq!(&"foobar", unimock.borrow_param(&"input").await);
-//     }
-
-//     #[tokio::test]
-//     async fn test_argument_borrowing_works() {
-//         let unimock = Unimock::with_assoc(
-//             BorrowParamMock::borrow_param::<&str>
-//                 .each_call(matching!(_))
-//                 .returns(&"foobar"),
-//         );
-
-//         unimock.borrow_param(&"input").await;
-//     }
-// }
-
-// mod lifetime_constrained_output_type {
-//     use super::*;
-
-//     #[derive(Clone)]
-//     pub struct Borrowing1<'a, T: ?Sized>(&'a T);
-
-//     #[derive(Clone)]
-//     pub struct Borrowing2<'a, 'b, T: ?Sized>(&'a T, &'b T);
-
-//     #[unimock(api=BorrowSyncMock)]
-//     trait BorrowSync {
-//         type X: ?Sized;
-
-//         fn borrow_sync_elided(&self) -> Borrowing1<'_, Self::X>;
-//         fn borrow_sync_explicit(&self) -> Borrowing1<'_, Self::X>;
-//         fn borrow_sync_explicit2<'a, 'b>(&'a self, arg: &'b str) -> Borrowing2<'a, 'b, Self::X>;
-//     }
-
-//     #[unimock(api=Unused)]
-//     #[async_trait(?Send)]
-//     trait BorrowAsync {
-//         type X;
-
-//         async fn borrow_async_elided(&self) -> Borrowing1<'_, Self::X>;
-//         async fn borrow_async_explicit<'a>(&'a self) -> Borrowing1<'a, Self::X>;
-//         async fn borrow_async_explicit2<'a, 'b>(
-//             &'a self,
-//             arg: &'b str,
-//         ) -> Borrowing2<'a, 'b, Self::X>;
-//     }
-
-//     #[test]
-//     fn test_borrow() {
-//         let deps = Unimock::with_assoc(
-//             BorrowSyncMock::borrow_sync_explicit2::<&str>
-//                 .some_call(matching!("foobar"))
-//                 .returns(Borrowing2(&"a", &"b")),
-//         );
-
-//         let result: Borrowing2<'_, '_, &str> = deps.borrow_sync_explicit2("foobar");
-//         assert_eq!(result.0, &"a");
-//         assert_eq!(result.1, &"b");
-//     }
-
-//     #[test]
-//     fn test_borrow_sized() {
-//         let deps = Unimock::with_assoc(
-//             BorrowSyncMock::borrow_sync_explicit2::<str>
-//                 .some_call(matching!("foobar"))
-//                 .returns(Borrowing2("a", "b")),
-//         );
-
-//         let result: Borrowing2<'_, '_, str> = deps.borrow_sync_explicit2("foobar");
-//         assert_eq!(result.0, "a");
-//         assert_eq!(result.1, "b");
-//     }
-// }
-
-// mod slice_matching {
-//     use std::vec;
-
-//     use super::*;
-
-//     #[unimock(api = Mock)]
-//     trait Trait {
-//         type X;
-
-//         type Y;
-
-//         fn vec_of_i32(&self, a: Vec<Self::X>);
-//         fn two_vec_of_i32(&self, a: Vec<Self::X>, b: Vec<Self::X>);
-//         fn vec_of_string(&self, a: Vec<Self::Y>);
-//     }
-
-//     #[test]
-//     fn vec_of_strings() {
-//         Unimock::<AssocType<_, AssocType<String>>>::with_assoc(
-//             Mock::vec_of_i32::<i32, String>
-//                 .next_call(matching!([1, 2]))
-//                 .returns(()),
-//         )
-//         .vec_of_i32(vec![1, 2]);
-//         Unimock::<AssocType<_, AssocType<String>>>::with_assoc(
-//             Mock::two_vec_of_i32::<i32, String>
-//                 .next_call(matching!([1, 2], [3, 4]))
-//                 .returns(()),
-//         )
-//         .two_vec_of_i32(vec![1, 2], vec![3, 4]);
-//         Unimock::<AssocType<i32, AssocType<_>>>::with_assoc(
-//             Mock::vec_of_string::<i32, String>
-//                 .next_call(matching!(([a, b]) if a == "1" && b == "2"))
-//                 .returns(()),
-//         )
-//         .vec_of_string(vec!["1".to_string(), "2".to_string()]);
-//     }
-// }
-
-// #[test]
-// fn eval_name_clash() {
-//     #[unimock(api = Mock, unmock_with=[unmock])]
-//     trait Trait {
-//         type X;
-
-//         fn tralala(&self, eval: Self::X);
-//     }
-
-//     fn unmock<X>(_: &impl std::any::Any, _: X) {}
-// }
-
-// #[test]
-// fn fn_cfg_attrs() {
-//     #[unimock(api = TraitMock)]
-//     trait Trait {
-//         type X;
-
-//         fn a(&self) -> Self::X;
-
-//         #[cfg(feature = "always-disabled")]
-//         fn b(&self) -> NonExistentType;
-//     }
-
-//     let u = Unimock::with_assoc(TraitMock::a::<i32>.next_call(matching!()).returns(0));
-//     assert_eq!(0, u.a());
-// }
-
-// mod output {
-//     use super::*;
-
-//     #[unimock(api=GenericOutputMock)]
-//     trait GenericOutput<T> {
-//         type X;
-//         fn generic_output(&self) -> T;
-//     }
-
-//     #[test]
-//     fn test_generic_return() {
-//         let deps: Unimock<AssocType<String>> = Unimock::with_assoc(
-//             GenericOutputMock::generic_output::<String>
-//                 .with_types::<String>()
-//                 .each_call(matching!())
-//                 .returns("success".to_string()),
-//         );
-
-//         let output = <Unimock<_> as GenericOutput<String>>::generic_output(&deps);
-//         assert_eq!("success", output);
-
-//         // let output = <Unimock as GenericOutput<i32>>::generic_output(&deps);
-//         // assert_eq!(42, output);
-//     }
-// }
-
-// mod param {
-//     use super::*;
-//     use std::fmt::Debug;
-
-//     #[unimock(api=GenericParamMock)]
-//     trait GenericParam<T> {
-//         type X;
-//         fn generic_param(&self, param: T) -> &'static str;
-//     }
-
-//     #[test]
-//     fn test_generic_param() {
-//         let deps: Unimock<AssocType<i32>> = Unimock::with_assoc((
-//             GenericParamMock::generic_param::<i32>
-//                 .with_types::<&'static str>()
-//                 .each_call(matching!("foobar"))
-//                 .returns("a string"),
-//             GenericParamMock::generic_param::<i32>
-//                 .with_types::<i32>()
-//                 .each_call(matching!(42))
-//                 .returns("a number"),
-//         ));
-
-//         assert_eq!("a string", deps.generic_param("foobar"));
-//         assert_eq!("a number", deps.generic_param(42_i32));
-//     }
-
-//     #[test]
-//     #[should_panic(
-//         // Since the generic parameter has no Debug bound, we cannot see the parameter:
-//         expected = "GenericParam::generic_param(?): No matching call patterns."
-//     )]
-//     fn test_generic_param_panic_no_debug() {
-//         let deps: Unimock<AssocType<i32>> = Unimock::with_assoc(
-//             GenericParamMock::generic_param::<i32>
-//                 .with_types::<i32>()
-//                 .each_call(matching!(1337))
-//                 .returns("a number"),
-//         );
-
-//         deps.generic_param(42_i32);
-//     }
-
-//     #[unimock(api=GenericParamDebugMock)]
-//     trait GenericParamDebug<T: Debug> {
-//         type X;
-//         fn generic_param_debug(&self, param: T) -> &'static str;
-//     }
-
-//     #[test]
-//     #[should_panic(
-//         // When it has a debug bound, we should see it:
-//         expected = "GenericParamDebug::generic_param_debug(42): No matching call patterns."
-//     )]
-//     fn test_generic_param_panic_debug() {
-//         let deps: Unimock<AssocType<i32>> = Unimock::with_assoc(
-//             GenericParamDebugMock::generic_param_debug::<i32>
-//                 .with_types::<i32>()
-//                 .each_call(matching!(1337))
-//                 .returns("a number"),
-//         );
-
-//         deps.generic_param_debug(42_i32);
-//     }
-// }
-
-// mod combined {
-//     use super::*;
-//     use std::fmt::Debug;
-
-//     #[unimock(api=A)]
-//     trait GenericBounds<I: Debug, O: Clone> {
-//         type X;
-//         fn generic_bounds(&self, param: I) -> O;
-//     }
-
-//     #[unimock(api=B)]
-//     trait GenericWhereBounds<I, O>
-//     where
-//         I: Debug,
-//         O: Clone,
-//     {
-//         type X;
-//         fn generic_where_bounds(&self, param: I) -> O;
-//     }
-// }
-
-// mod async_generic {
-//     use super::*;
-//     use std::fmt::Debug;
-
-//     #[unimock(api=A)]
-//     #[async_trait::async_trait(?Send)]
-//     trait AsyncTraitGenericBounds<I: Debug, O: Clone> {
-//         type X;
-//         async fn generic_bounds(&self, param: I) -> O;
-//     }
-// }
-
-// mod generic_without_module {
-//     use super::*;
-//     use std::fmt::Debug;
-
-//     #[unimock(api=[Func])]
-//     trait WithModule<T: Debug> {
-//         type X;
-//         fn func(&self) -> T;
-//     }
-
-//     #[test]
-//     fn mock() {
-//         Func::<i32>
-//             .with_types::<String>()
-//             .each_call(matching!())
-//             .returns("".to_string());
-//     }
-// }
-
-// mod generic_with_unmock {
-//     use super::*;
-
-//     // unmock is not implemented
-
-//     // #[unimock(unmock_with=[gen_default(self)])]
-//     // trait UnmockMe<T: Default> {
-//     //     type X;
-//     //     fn unmock_me(&self) -> T;
-//     // }
-
-//     // #[unimock(unmock_with=[gen_default(self)])]
-//     // trait UnmockMeWhere<T>
-//     // where
-//     //     T: Default,
-//     // {
-//     //     type X;
-//     //     fn unmock_me_where(&self) -> T;
-//     // }
-
-//     fn gen_default<D, T: Default>(_: &D) -> T {
-//         T::default()
-//     }
-// }
-
-// use unimock::*;
-
-// mod clone {
-
-//     #[derive(Eq, PartialEq, Debug)]
-//     pub struct Nope;
-
-//     #[derive(Clone, Eq, PartialEq, Debug)]
-//     pub struct Sure;
-// }
-
-// #[unimock(api=InOptionMock)]
-// trait InOption {
-//     type X;
-//     fn str(&self, a: &str) -> Option<&str>;
-//     fn not_clone(&self) -> Option<&clone::Nope>;
-// }
-
-// #[test]
-// fn in_option() {
-//     let u: Unimock<AssocType<()>> = Unimock::with_assoc((
-//         InOptionMock::str::<()>
-//             .next_call(matching!(_))
-//             .returns(Some("1".to_string())),
-//         InOptionMock::str::<()>
-//             .next_call(matching!(_))
-//             .returns(Some("2")),
-//         InOptionMock::str::<()>
-//             .next_call(matching!(_))
-//             .returns(None::<&str>),
-//     ));
-//     assert_eq!(Some("1"), u.str(""));
-//     assert_eq!(Some("2"), u.str(""));
-//     assert_eq!(None, u.str(""));
-// }
-
-// // This test demonstrates that a `T: Clone` bound is not necessary
-// // on each_call for `Option<&T>`, since the outer option
-// // can be generically reconstructed from the inner borrowed one
-// #[test]
-// fn in_option_not_clone_can_clone_anyway() {
-//     let u: Unimock<AssocType<()>> = Unimock::with_assoc(
-//         InOptionMock::not_clone::<()>
-//             .each_call(matching!())
-//             .returns(Some(clone::Nope)),
-//     );
-//     assert_eq!(Some(&clone::Nope), <Unimock<_> as InOption>::not_clone(&u));
-//     assert_eq!(Some(&clone::Nope), <Unimock<_> as InOption>::not_clone(&u));
-// }
-
-// #[unimock(api=InResultMock)]
-// trait InResult {
-//     type X;
-//     fn bytes(&self) -> Result<&[u8], clone::Nope>;
-//     fn u32_clone(&self) -> Result<&u32, clone::Sure>;
-//     fn ok_no_clone(&self, ok: bool) -> Result<&clone::Nope, clone::Sure>;
-//     fn err_no_clone(&self) -> Result<&clone::Nope, clone::Nope>;
-// }
-
-// #[test]
-// fn in_result() {
-//     let u: Unimock<AssocType<()>> = Unimock::with_assoc((
-//         InResultMock::bytes::<()>
-//             .next_call(matching!())
-//             .returns(Ok(vec![42])),
-//         InResultMock::bytes::<()>
-//             .next_call(matching!())
-//             .returns(Err::<&[u8], _>(clone::Nope)),
-//         InResultMock::u32_clone::<()>
-//             .each_call(matching!())
-//             .returns(Ok(42))
-//             .at_least_times(2),
-//     ));
-
-//     assert_eq!(Ok(vec![42].as_slice()), <Unimock<_> as InResult>::bytes(&u));
-//     assert_eq!(Err(clone::Nope), <Unimock<_> as InResult>::bytes(&u));
-//     assert_eq!(Ok(&42), <Unimock<_> as InResult>::u32_clone(&u));
-//     assert_eq!(Ok(&42), <Unimock<_> as InResult>::u32_clone(&u));
-// }
-
-// #[test]
-// fn in_result_clone_acrobatics() {
-//     let u: Unimock<AssocType<()>> = Unimock::with_assoc((
-//         InResultMock::ok_no_clone::<()>
-//             .each_call(matching!(true))
-//             .returns(Ok(clone::Nope)),
-//         InResultMock::ok_no_clone::<()>
-//             .each_call(matching!(false))
-//             .returns(Err::<&clone::Nope, _>(clone::Sure)),
-//         InResultMock::err_no_clone::<()>
-//             .some_call(matching!()) // note: .each_call is impossible
-//             .returns(Err::<&clone::Nope, _>(clone::Nope)),
-//     ));
-
-//     for _ in 0..3 {
-//         assert_eq!(Ok(&clone::Nope), u.ok_no_clone(true));
-//         assert_eq!(Err(clone::Sure), u.ok_no_clone(false));
-//     }
-
-//     assert_eq!(Err(clone::Nope), u.err_no_clone());
-// }
-
-// #[test]
-// #[should_panic(
-//     expected = "InResult::ok_no_clone: Expected InResult::ok_no_clone(_) at tests/it/assoc_types.rs:1105 to match exactly 1 call, but it actually matched 2 calls."
-// )]
-// fn in_result_may_multi_respond_on_ok_no_clone() {
-//     let u: Unimock<AssocType<()>> = Unimock::with_assoc(
-//         InResultMock::ok_no_clone::<()>
-//             .some_call(matching!(_))
-//             .returns(Ok(clone::Nope)),
-//     );
-
-//     assert_eq!(Ok(&clone::Nope), u.ok_no_clone(true));
-//     assert_eq!(Ok(&clone::Nope), u.ok_no_clone(true));
-// }
-
-// #[unimock(api = InVecMock)]
-// trait InVec {
-//     type X;
-//     fn vector(&self) -> Vec<&i32>;
-// }
-
-// #[test]
-// fn in_vec() {
-//     let u: Unimock<AssocType<()>> = Unimock::with_assoc(
-//         InVecMock::vector::<()>
-//             .each_call(matching!())
-//             .returns(vec![1, 2, 3]),
-//     );
-
-//     assert_eq!(vec![&1, &2, &3], u.vector());
-// }
-
-// #[unimock(api = MixedTupleMock)]
-// trait MixedTuple {
-//     type X;
-//     fn tuple1(&self) -> (&i32,);
-//     fn tuple2a(&self) -> (&i32, i32);
-//     fn tuple2b(&self) -> (i32, &i32);
-//     fn tuple4(&self) -> (&clone::Nope, clone::Nope, &clone::Sure, clone::Sure);
-// }
-
-// #[test]
-// fn mixed_tuple1() {
-//     let u: Unimock<AssocType<()>> = Unimock::with_assoc((
-//         MixedTupleMock::tuple2a::<()>
-//             .next_call(matching!())
-//             .returns((1, 2)),
-//         MixedTupleMock::tuple2b::<()>
-//             .next_call(matching!())
-//             .returns((1, 2)),
-//     ));
-
-//     assert_eq!((&1, 2), u.tuple2a());
-//     assert_eq!((1, &2), u.tuple2b());
-// }
-
-// #[test]
-// fn mixed_tuple_clone_combinatorics_once() {
-//     let u: Unimock<AssocType<()>> = Unimock::with_assoc(
-//         MixedTupleMock::tuple4::<()>
-//             .next_call(matching!())
-//             .returns((clone::Nope, clone::Nope, clone::Sure, clone::Sure)),
-//     );
-
-//     assert_eq!(
-//         (&clone::Nope, clone::Nope, &clone::Sure, clone::Sure),
-//         u.tuple4()
-//     );
-// }
-
-// #[test]
-// fn mixed_tuple_clone_combinatorics_many() {
-//     let u: Unimock<AssocType<()>> = Unimock::with_assoc(
-//         MixedTupleMock::tuple4::<()>
-//             .each_call(matching!())
-//             .answers(|_| (clone::Nope, clone::Nope, clone::Sure, clone::Sure)),
-//     );
-
-//     for _ in 0..3 {
-//         assert_eq!(
-//             (&clone::Nope, clone::Nope, &clone::Sure, clone::Sure),
-//             u.tuple4()
-//         );
-//     }
-// }
+#[test]
+fn noarg_works() {
+    #[unimock(api=NoArgMock)]
+    trait NoArg {
+        type X;
+
+        fn no_arg(&self) -> Self::X;
+    }
+
+    assert_eq!(
+        1_000_000,
+        Unimock::with_assoc(
+            NoArgMock::no_arg::<i32>
+                .next_call(matching!())
+                .returns(1_000_000)
+        )
+        .no_arg()
+    );
+}
+
+#[test]
+fn owned_output_works() {
+    #[unimock(api=OwnedMock)]
+    trait Owned {
+        type X;
+
+        fn foo(&self, a: String, b: Self::X) -> Self::X;
+    }
+
+    fn takes_owned<O: Owned<X = String>>(
+        o: &O,
+        a: impl Into<String>,
+        b: impl Into<O::X>,
+    ) -> String {
+        o.foo(a.into(), b.into())
+    }
+
+    assert_eq!(
+        "ab",
+        takes_owned(
+            &Unimock::with_assoc(
+                OwnedMock::foo::<String>
+                    .next_call(matching!(_, _))
+                    .answers(|(a, b)| format!("{a}{b}"))
+                    .once()
+            ),
+            "a",
+            "b",
+        )
+    );
+    assert_eq!(
+        "lol",
+        takes_owned(
+            &Unimock::with_assoc(OwnedMock::foo::<String>.stub(|each| {
+                each.call(matching!(_, _)).returns("lol");
+            })),
+            "a",
+            "b",
+        )
+    );
+    assert_eq!(
+        "",
+        takes_owned(
+            &Unimock::with_assoc(OwnedMock::foo::<String>.stub(|each| {
+                each.call(matching!("a", "b")).returns_default();
+            })),
+            "a",
+            "b",
+        )
+    );
+}
+
+mod exotic_self_types {
+    use super::*;
+    use std::rc::Rc;
+
+    #[unimock(api=OwnedSelfMock)]
+    trait OwnedSelf {
+        type X;
+
+        fn foo(self);
+    }
+
+    #[unimock(api=MutSelfMock)]
+    trait MutSelf {
+        type X;
+
+        fn mut_self(&mut self);
+    }
+
+    #[unimock(api=RcSelfMock)]
+    trait RcSelf {
+        type X;
+
+        fn rc_self(self: Rc<Self>);
+    }
+
+    #[test]
+    fn mut_self() {
+        let mut u: Unimock<AssocType<i32>> = Unimock::with_assoc(
+            MutSelfMock::mut_self::<i32>
+                .each_call(matching!())
+                .returns(()),
+        );
+
+        u.mut_self();
+    }
+
+    #[test]
+    fn rc_self() {
+        let deps: Rc<Unimock<AssocType<i32>>> = Rc::new(Unimock::with_assoc(
+            RcSelfMock::rc_self::<i32>
+                .each_call(matching!())
+                .returns(()),
+        ));
+
+        deps.rc_self();
+    }
+}
+
+mod exotic_methods {
+    use super::*;
+
+    #[unimock(api=ProvidedMock)]
+    trait Provided {
+        type X: Default;
+
+        fn not_provided(&self);
+        fn provided(&self) -> Self::X {
+            Self::X::default()
+        }
+    }
+
+    #[test]
+    fn test_provided() {
+        let deps = Unimock::with_assoc(
+            ProvidedMock::provided::<i32>
+                .each_call(matching!())
+                .returns(42),
+        );
+        assert_eq!(42, deps.provided());
+    }
+
+    #[unimock]
+    trait SkipStaticProvided {
+        type X;
+
+        fn skip1() {}
+        fn skip2(arg: i32) -> i32 {
+            arg
+        }
+    }
+}
+
+mod referenced {
+    use super::*;
+
+    #[unimock(api=ReferencedMock)]
+    trait Referenced {
+        type X;
+
+        fn foo(&self, a: &str) -> &str;
+        fn bar(&self, a: &str, b: &str) -> &str;
+    }
+
+    fn takes_referenced<'s, 'x, R: Referenced<X = &'x str>>(r: &'s R, a: R::X) -> &'s str {
+        r.foo(a)
+    }
+
+    #[test]
+    fn referenced_with_static_return_value_works() {
+        let u = Unimock::with_assoc(ReferencedMock::foo::<&str>.stub(|each| {
+            each.call(matching!("a")).returns("answer".to_string());
+        }));
+        assert_eq!("answer", takes_referenced(&u, "a",));
+    }
+
+    #[test]
+    fn referenced_with_default_return_value_works() {
+        let u = Unimock::with_assoc(ReferencedMock::foo::<&str>.stub(|each| {
+            each.call(matching!("Æ")).panics("Should not be called");
+            each.call(matching!("a")).returns(String::new());
+        }));
+        assert_eq!("", takes_referenced(&u, "a",));
+    }
+
+    #[test]
+    fn referenced_with_static_ref_works() {
+        let u = Unimock::with_assoc(ReferencedMock::foo::<&str>.stub(|each| {
+            each.call(matching!("a")).returns("foobar");
+        }));
+        assert_eq!("foobar", takes_referenced(&u, "a",));
+    }
+}
+
+mod no_clone_return {
+    use unimock::*;
+
+    #[derive(Debug, PartialEq)]
+    pub struct NoClone(i32);
+
+    #[unimock(api=FooMock)]
+    trait Foo {
+        type X;
+
+        fn foo(&self) -> Self::X;
+    }
+
+    #[test]
+    fn test_no_clone_return() {
+        let u = Unimock::with_assoc(
+            FooMock::foo::<NoClone>
+                .some_call(matching!())
+                .returns(NoClone(55)),
+        );
+        assert_eq!(NoClone(55), u.foo());
+    }
+}
+
+mod each_call_implicitly_clones {
+    use unimock::*;
+
+    #[unimock(api=FooMock)]
+    trait Foo {
+        type X;
+
+        fn foo(&self) -> Self::X;
+    }
+
+    #[test]
+    fn each_call_implicit_clone() {
+        let u = Unimock::with_assoc(FooMock::foo::<i32>.each_call(matching!()).returns(55));
+        assert_eq!(55, u.foo());
+        assert_eq!(55, u.foo());
+    }
+}
+
+#[unimock(api=SingleArgMock)]
+trait SingleArg {
+    type X;
+
+    fn method1<'i>(&'i self, a: &'i str) -> &'i Self::X;
+}
+
+#[unimock(api=MultiArgMock)]
+trait MultiArg {
+    type X;
+
+    fn method2(&self, a: &str, b: &str) -> &Self::X;
+}
+
+#[test]
+fn test_multiple() {
+    fn takes_single_multi(
+        t: &(impl SingleArg<X = &'static str> + MultiArg<X = &'static str>),
+    ) -> &str {
+        let tmp = t.method1("b");
+        t.method2(tmp, tmp)
+    }
+
+    let u = Unimock::with_assoc((
+        SingleArgMock::method1::<&'static str>.stub(|each| {
+            each.call(matching!("b")).returns("B").once();
+        }),
+        MultiArgMock::method2::<&'static str>.stub(|each| {
+            each.call(matching!("a", _)).panics("should not call this");
+            each.call(matching!("B", "B")).returns("success").once();
+        }),
+    ));
+    assert_eq!("success", takes_single_multi(&u));
+}
+
+mod no_debug {
+    use super::*;
+
+    pub enum PrimitiveEnum {
+        Foo,
+        Bar,
+    }
+
+    #[unimock(api=VeryPrimitiveMock)]
+    trait VeryPrimitive {
+        type X;
+
+        fn primitive(&self, a: PrimitiveEnum, b: Self::X) -> PrimitiveEnum;
+    }
+
+    #[test]
+    fn can_match_a_non_debug_argument() {
+        match Unimock::with_assoc(VeryPrimitiveMock::primitive::<&str>.stub(|each| {
+            each.call(matching!(PrimitiveEnum::Bar, _))
+                .answers(|_| PrimitiveEnum::Foo);
+        }))
+        .primitive(PrimitiveEnum::Bar, "")
+        {
+            PrimitiveEnum::Foo => {}
+            PrimitiveEnum::Bar => panic!(),
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "VeryPrimitive::primitive(?, ?): No matching call patterns.")]
+    fn should_format_non_debug_input_with_a_question_mark() {
+        Unimock::with_assoc(VeryPrimitiveMock::primitive::<&str>.stub(|each| {
+            each.call(matching!(PrimitiveEnum::Bar, _))
+                .answers(|_| PrimitiveEnum::Foo);
+        }))
+        .primitive(PrimitiveEnum::Foo, "");
+    }
+}
+
+#[test]
+fn should_debug_reference_to_debug_implementing_type() {
+    #[derive(Debug)]
+    pub enum DebugEnum {}
+
+    #[unimock(api=A)]
+    trait VeryPrimitiveRefZero {
+        type X;
+
+        fn primitive_ref(&self, a: DebugEnum) -> DebugEnum;
+    }
+
+    #[unimock(api=B)]
+    trait VeryPrimitiveRefOnce {
+        type X;
+
+        fn primitive_ref(&self, a: &DebugEnum) -> DebugEnum;
+    }
+
+    #[unimock(api=C)]
+    trait VeryPrimitiveRefTwice {
+        type X;
+
+        fn primitive_ref(&self, a: &&DebugEnum) -> DebugEnum;
+    }
+}
+
+#[test]
+fn should_be_able_to_borrow_a_returns_value() {
+    #[derive(Eq, PartialEq, Debug, Clone)]
+    pub struct Ret<T>(T);
+
+    #[unimock(api=BorrowsRetMock)]
+    trait BorrowsRet {
+        type X;
+
+        fn borrows_ret(&self) -> &Ret<Self::X>;
+    }
+
+    assert_eq!(
+        &Ret(42),
+        Unimock::with_assoc(
+            BorrowsRetMock::borrows_ret::<i32>
+                .each_call(matching!())
+                .returns(&Ret(42))
+        )
+        .borrows_ret()
+    );
+}
+
+#[test]
+fn various_borrowing() {
+    #[unimock(api=BorrowingMock)]
+    trait Borrowing {
+        type X;
+
+        fn borrow(&self, input: Self::X) -> &Self::X;
+        fn borrow_static(&self) -> &'static Self::X;
+    }
+    fn get_str<'s, B: Borrowing<X = String>>(t: &'s B, input: &str) -> &'s str {
+        t.borrow(input.to_string()).as_str()
+    }
+
+    let u = Unimock::with_assoc(
+        BorrowingMock::borrow::<String>
+            .next_call(matching!(_))
+            .returns("foo".to_string())
+            .once(),
+    );
+    assert_eq!("foo", get_str(&u, ""));
+    let u = Unimock::with_assoc(
+        BorrowingMock::borrow::<String>
+            .next_call(matching!(_))
+            .returns("foo".to_string())
+            .once(),
+    );
+    assert_eq!("foo", get_str(&u, ""));
+    let u = Unimock::with_assoc(
+        BorrowingMock::borrow::<String>
+            .next_call(matching!(_))
+            .answers(|input| format!("{input}{input}"))
+            .once(),
+    );
+    assert_eq!("yoyo", get_str(&u, "yo"));
+    let u: Unimock<AssocType<String>> = Unimock::with_assoc(
+        BorrowingMock::borrow_static::<String>
+            .next_call(matching!(_))
+            .answers_leaked_ref(|_| format!("yoyoyo"))
+            .once(),
+    );
+    assert_eq!("yoyoyo", u.borrow_static());
+}
+
+mod custom_api_module {
+    use unimock::*;
+
+    pub struct MyType;
+
+    #[unimock(api=FakeSingle)]
+    trait Single {
+        type X;
+
+        fn func(&self) -> &Self::X;
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "Single::func: Expected Single::func(_) at tests/it/assoc_types.rs:427 to match exactly 1 call, but it actually matched no calls.\nMock for Single::func was never called. Dead mocks should be removed."
+    )]
+    fn test_without_module() {
+        Unimock::<AssocType<MyType>>::with_assoc(
+            FakeSingle::func::<MyType>
+                .next_call(matching!(_))
+                .returns(MyType)
+                .once(),
+        );
+    }
+}
+
+mod flattened_module {
+    mod assoc_types {
+        use unimock::*;
+
+        #[unimock(api=[Foo, Bar])]
+        trait WithUnpackedModule {
+            type X;
+
+            fn foo(&self, input: String) -> i32;
+            fn bar(&self);
+        }
+
+        #[test]
+        fn test_unpacked_module() {
+            let _ = Foo::<i32>.each_call(matching!(_)).returns(33);
+            let _ = Bar::<()>.each_call(matching!(_)).returns(());
+        }
+    }
+
+    mod generics {
+        use unimock::*;
+
+        #[unimock(api=[Foo, Bar])]
+        trait UnpackedGenerics<T> {
+            type X;
+
+            fn foo(&self, input: String) -> T;
+            fn bar(&self, input: &T);
+        }
+    }
+
+    mod exports {
+        mod inner {
+            use unimock::*;
+            #[unimock(api=[FooMock])]
+            pub trait Trait {
+                type X;
+
+                fn foo(&self);
+            }
+        }
+
+        #[test]
+        fn test_inner() {
+            use unimock::*;
+            let _ = inner::FooMock::<i32>.each_call(matching!()).returns(());
+        }
+    }
+}
+
+#[unimock(api=AsyncMock)]
+#[async_trait(?Send)]
+trait Async {
+    type X;
+
+    async fn func(&self, arg: Self::X) -> String;
+}
+
+#[tokio::test]
+async fn test_async_trait() {
+    async fn takes_async<A: Async>(a: &A, arg: A::X) -> String {
+        a.func(arg).await
+    }
+
+    assert_eq!(
+        "42",
+        takes_async(
+            &Unimock::with_assoc(AsyncMock::func::<i32>.stub(|each| {
+                each.call(matching!(_)).returns("42");
+            })),
+            21
+        )
+        .await
+    );
+}
+
+use std::borrow::Cow;
+
+#[unimock(api=CowBasedMock)]
+trait CowBased {
+    type X: ?Sized + ToOwned;
+
+    fn func(&self, arg: Cow<'static, Self::X>) -> Cow<'static, Self::X>;
+}
+
+#[test]
+fn test_cow() {
+    fn takes<C: CowBased>(t: &C, arg: Cow<'static, C::X>) -> Cow<'static, C::X> {
+        t.func(arg)
+    }
+
+    assert_eq!(
+        "output",
+        takes(
+            &Unimock::with_assoc(CowBasedMock::func::<str>.stub(|each| {
+                each.call(matching! {("input") | ("foo")}).returns("output");
+            })),
+            "input".into()
+        )
+    );
+}
+
+#[test]
+fn borrow_intricate_lifetimes() {
+    pub struct I<'s>(std::marker::PhantomData<&'s ()>);
+    pub struct O<'s>(&'s String);
+
+    #[unimock(api = IntricateMock)]
+    trait Intricate {
+        type X;
+
+        fn foo<'s, 't>(&'s self, inp: &'t I<'s>) -> &'s O<'t>;
+    }
+
+    fn takes_intricate(i: &impl Intricate) {
+        i.foo(&I(std::marker::PhantomData));
+    }
+
+    let u: Unimock<AssocType<()>> = Unimock::with_assoc(
+        IntricateMock::foo::<()>
+            .next_call(matching!(I(_)))
+            .returns(O(Box::leak(Box::new("leaked".to_string())))),
+    );
+
+    takes_intricate(&u);
+}
+
+#[test]
+fn clause_helpers() {
+    #[unimock(api=FooMock)]
+    trait Foo {
+        type X;
+
+        fn m1(&self) -> Self::X;
+    }
+
+    #[unimock(api=BarMock)]
+    trait Bar {
+        type X;
+
+        fn m2(&self) -> Self::X;
+    }
+    #[unimock(api=BazMock)]
+    trait Baz {
+        type X;
+
+        fn m3(&self) -> Self::X;
+    }
+
+    fn setup_foo_bar() -> impl Clause {
+        (
+            FooMock::m1::<i32>.some_call(matching!(_)).returns(1),
+            BarMock::m2::<i32>.each_call(matching!(_)).returns(2),
+        )
+    }
+
+    let deps: Unimock<AssocType<i32>> = Unimock::with_assoc((
+        setup_foo_bar(),
+        BazMock::m3::<i32>.each_call(matching!(_)).returns(3),
+    ));
+    assert_eq!(6, deps.m1() + deps.m2() + deps.m3());
+}
+
+mod responders_in_series {
+    use super::*;
+
+    #[unimock(api=SeriesMock)]
+    trait Series {
+        type X;
+
+        fn series(&self) -> Self::X;
+    }
+
+    fn clause() -> impl Clause {
+        SeriesMock::series::<i32>
+            .each_call(matching!())
+            .returns(1)
+            .once()
+            .then()
+            .returns(2)
+            .n_times(2)
+            .then()
+            .returns(3)
+            .at_least_times(1)
+    }
+
+    #[test]
+    fn responder_series_should_work() {
+        let a = Unimock::with_assoc(clause());
+
+        assert_eq!(1, a.series());
+        assert_eq!(2, a.series());
+        assert_eq!(2, a.series());
+        // it will continue to return 3:
+        assert_eq!(3, a.series());
+        assert_eq!(3, a.series());
+        assert_eq!(3, a.series());
+        assert_eq!(3, a.series());
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "Series::series: Expected Series::series() at tests/it/assoc_types.rs:609 to match at least 4 calls, but it actually matched 2 calls."
+    )]
+    fn series_not_fully_generated_should_panic() {
+        let b = Unimock::with_assoc(clause());
+
+        assert_eq!(1, b.series());
+        assert_eq!(2, b.series());
+
+        // Exact repetition was defined to be 4 (the last responder is not exactly quantified), but it contained a `.then` call so minimum 1.
+    }
+}
+
+#[unimock(api=BorrowStaticMock)]
+trait BorrowStatic {
+    type X;
+
+    fn static_str(&self, arg: Self::X) -> &'static str;
+}
+
+#[test]
+fn borrow_static_should_work_with_returns_static() {
+    assert_eq!(
+        "foo",
+        Unimock::with_assoc(
+            BorrowStaticMock::static_str::<i32>
+                .next_call(matching!(_))
+                .returns("foo")
+        )
+        .static_str(33)
+    );
+}
+
+mod async_argument_borrowing {
+    use super::*;
+
+    #[unimock(api=BorrowParamMock)]
+    #[async_trait(?Send)]
+    trait BorrowParam {
+        type X;
+
+        async fn borrow_param<'a>(&self, arg: &'a Self::X) -> &'a Self::X;
+    }
+
+    #[tokio::test]
+    async fn test_argument_borrowing() {
+        let unimock = Unimock::with_assoc(
+            BorrowParamMock::borrow_param::<&str>
+                .each_call(matching!(_))
+                .returns(&"foobar"),
+        );
+
+        assert_eq!(&"foobar", unimock.borrow_param(&"input").await);
+    }
+
+    #[tokio::test]
+    async fn test_argument_borrowing_works() {
+        let unimock = Unimock::with_assoc(
+            BorrowParamMock::borrow_param::<&str>
+                .each_call(matching!(_))
+                .returns(&"foobar"),
+        );
+
+        unimock.borrow_param(&"input").await;
+    }
+}
+
+mod lifetime_constrained_output_type {
+    use super::*;
+
+    #[derive(Clone)]
+    pub struct Borrowing1<'a, T: ?Sized>(&'a T);
+
+    #[derive(Clone)]
+    pub struct Borrowing2<'a, 'b, T: ?Sized>(&'a T, &'b T);
+
+    #[unimock(api=BorrowSyncMock)]
+    trait BorrowSync {
+        type X: ?Sized;
+
+        fn borrow_sync_elided(&self) -> Borrowing1<'_, Self::X>;
+        fn borrow_sync_explicit(&self) -> Borrowing1<'_, Self::X>;
+        fn borrow_sync_explicit2<'a, 'b>(&'a self, arg: &'b str) -> Borrowing2<'a, 'b, Self::X>;
+    }
+
+    #[unimock(api=Unused)]
+    #[async_trait(?Send)]
+    trait BorrowAsync {
+        type X;
+
+        async fn borrow_async_elided(&self) -> Borrowing1<'_, Self::X>;
+        async fn borrow_async_explicit<'a>(&'a self) -> Borrowing1<'a, Self::X>;
+        async fn borrow_async_explicit2<'a, 'b>(
+            &'a self,
+            arg: &'b str,
+        ) -> Borrowing2<'a, 'b, Self::X>;
+    }
+
+    #[test]
+    fn test_borrow() {
+        let deps = Unimock::with_assoc(
+            BorrowSyncMock::borrow_sync_explicit2::<&str>
+                .some_call(matching!("foobar"))
+                .returns(Borrowing2(&"a", &"b")),
+        );
+
+        let result: Borrowing2<'_, '_, &str> = deps.borrow_sync_explicit2("foobar");
+        assert_eq!(result.0, &"a");
+        assert_eq!(result.1, &"b");
+    }
+
+    #[test]
+    fn test_borrow_sized() {
+        let deps = Unimock::with_assoc(
+            BorrowSyncMock::borrow_sync_explicit2::<str>
+                .some_call(matching!("foobar"))
+                .returns(Borrowing2("a", "b")),
+        );
+
+        let result: Borrowing2<'_, '_, str> = deps.borrow_sync_explicit2("foobar");
+        assert_eq!(result.0, "a");
+        assert_eq!(result.1, "b");
+    }
+}
+
+mod slice_matching {
+    use std::vec;
+
+    use super::*;
+
+    #[unimock(api = Mock)]
+    trait Trait {
+        type X;
+
+        type Y;
+
+        fn vec_of_i32(&self, a: Vec<Self::X>);
+        fn two_vec_of_i32(&self, a: Vec<Self::X>, b: Vec<Self::X>);
+        fn vec_of_string(&self, a: Vec<Self::Y>);
+    }
+
+    #[test]
+    fn vec_of_strings() {
+        Unimock::<AssocType<_, AssocType<String>>>::with_assoc(
+            Mock::vec_of_i32::<i32, String>
+                .next_call(matching!([1, 2]))
+                .returns(()),
+        )
+        .vec_of_i32(vec![1, 2]);
+        Unimock::<AssocType<_, AssocType<String>>>::with_assoc(
+            Mock::two_vec_of_i32::<i32, String>
+                .next_call(matching!([1, 2], [3, 4]))
+                .returns(()),
+        )
+        .two_vec_of_i32(vec![1, 2], vec![3, 4]);
+        Unimock::<AssocType<i32, AssocType<_>>>::with_assoc(
+            Mock::vec_of_string::<i32, String>
+                .next_call(matching!(([a, b]) if a == "1" && b == "2"))
+                .returns(()),
+        )
+        .vec_of_string(vec!["1".to_string(), "2".to_string()]);
+    }
+}
+
+#[test]
+fn eval_name_clash() {
+    #[unimock(api = Mock, unmock_with=[unmock])]
+    trait Trait {
+        type X;
+
+        fn tralala(&self, eval: Self::X);
+    }
+
+    fn unmock<X>(_: &impl std::any::Any, _: X) {}
+}
+
+#[test]
+fn fn_cfg_attrs() {
+    #[unimock(api = TraitMock)]
+    trait Trait {
+        type X;
+
+        fn a(&self) -> Self::X;
+
+        #[cfg(feature = "always-disabled")]
+        fn b(&self) -> NonExistentType;
+    }
+
+    let u = Unimock::with_assoc(TraitMock::a::<i32>.next_call(matching!()).returns(0));
+    assert_eq!(0, u.a());
+}
+
+mod output {
+    use super::*;
+
+    #[unimock(api=GenericOutputMock)]
+    trait GenericOutput<T> {
+        type X;
+        fn generic_output(&self) -> T;
+    }
+
+    #[test]
+    fn test_generic_return() {
+        let deps: Unimock<AssocType<String>> = Unimock::with_assoc(
+            GenericOutputMock::generic_output::<String>
+                .with_types::<String>()
+                .each_call(matching!())
+                .returns("success".to_string()),
+        );
+
+        let output = <Unimock<_> as GenericOutput<String>>::generic_output(&deps);
+        assert_eq!("success", output);
+
+        // let output = <Unimock as GenericOutput<i32>>::generic_output(&deps);
+        // assert_eq!(42, output);
+    }
+}
+
+mod param {
+    use super::*;
+    use std::fmt::Debug;
+
+    #[unimock(api=GenericParamMock)]
+    trait GenericParam<T> {
+        type X;
+        fn generic_param(&self, param: T) -> &'static str;
+    }
+
+    #[test]
+    fn test_generic_param() {
+        let deps: Unimock<AssocType<i32>> = Unimock::with_assoc((
+            GenericParamMock::generic_param::<i32>
+                .with_types::<&'static str>()
+                .each_call(matching!("foobar"))
+                .returns("a string"),
+            GenericParamMock::generic_param::<i32>
+                .with_types::<i32>()
+                .each_call(matching!(42))
+                .returns("a number"),
+        ));
+
+        assert_eq!("a string", deps.generic_param("foobar"));
+        assert_eq!("a number", deps.generic_param(42_i32));
+    }
+
+    #[test]
+    #[should_panic(
+        // Since the generic parameter has no Debug bound, we cannot see the parameter:
+        expected = "GenericParam::generic_param(?): No matching call patterns."
+    )]
+    fn test_generic_param_panic_no_debug() {
+        let deps: Unimock<AssocType<i32>> = Unimock::with_assoc(
+            GenericParamMock::generic_param::<i32>
+                .with_types::<i32>()
+                .each_call(matching!(1337))
+                .returns("a number"),
+        );
+
+        deps.generic_param(42_i32);
+    }
+
+    #[unimock(api=GenericParamDebugMock)]
+    trait GenericParamDebug<T: Debug> {
+        type X;
+        fn generic_param_debug(&self, param: T) -> &'static str;
+    }
+
+    #[test]
+    #[should_panic(
+        // When it has a debug bound, we should see it:
+        expected = "GenericParamDebug::generic_param_debug(42): No matching call patterns."
+    )]
+    fn test_generic_param_panic_debug() {
+        let deps: Unimock<AssocType<i32>> = Unimock::with_assoc(
+            GenericParamDebugMock::generic_param_debug::<i32>
+                .with_types::<i32>()
+                .each_call(matching!(1337))
+                .returns("a number"),
+        );
+
+        deps.generic_param_debug(42_i32);
+    }
+}
+
+mod combined {
+    use super::*;
+    use std::fmt::Debug;
+
+    #[unimock(api=A)]
+    trait GenericBounds<I: Debug, O: Clone> {
+        type X;
+        fn generic_bounds(&self, param: I) -> O;
+    }
+
+    #[unimock(api=B)]
+    trait GenericWhereBounds<I, O>
+    where
+        I: Debug,
+        O: Clone,
+    {
+        type X;
+        fn generic_where_bounds(&self, param: I) -> O;
+    }
+}
+
+mod async_generic {
+    use super::*;
+    use std::fmt::Debug;
+
+    #[unimock(api=A)]
+    #[async_trait::async_trait(?Send)]
+    trait AsyncTraitGenericBounds<I: Debug, O: Clone> {
+        type X;
+        async fn generic_bounds(&self, param: I) -> O;
+    }
+}
+
+mod generic_without_module {
+    use super::*;
+    use std::fmt::Debug;
+
+    #[unimock(api=[Func])]
+    trait WithModule<T: Debug> {
+        type X;
+        fn func(&self) -> T;
+    }
+
+    #[test]
+    fn mock() {
+        Func::<i32>
+            .with_types::<String>()
+            .each_call(matching!())
+            .returns("".to_string());
+    }
+}
+
+mod generic_with_unmock {
+    // use super::*;
+
+    // FIXME: unmock is not implemented
+
+    // #[unimock(unmock_with=[gen_default(self)])]
+    // trait UnmockMe<T: Default> {
+    //     type X;
+    //     fn unmock_me(&self) -> T;
+    // }
+
+    // #[unimock(unmock_with=[gen_default(self)])]
+    // trait UnmockMeWhere<T>
+    // where
+    //     T: Default,
+    // {
+    //     type X;
+    //     fn unmock_me_where(&self) -> T;
+    // }
+
+    // fn gen_default<D, T: Default>(_: &D) -> T {
+    //     T::default()
+    // }
+}
+
+mod clone {
+
+    #[derive(Eq, PartialEq, Debug)]
+    pub struct Nope;
+
+    #[derive(Clone, Eq, PartialEq, Debug)]
+    pub struct Sure;
+}
+
+#[unimock(api=InOptionMock)]
+trait InOption {
+    type X;
+    fn str(&self, a: &str) -> Option<&str>;
+    fn not_clone(&self) -> Option<&clone::Nope>;
+}
+
+#[test]
+fn in_option() {
+    let u: Unimock<AssocType<()>> = Unimock::with_assoc((
+        InOptionMock::str::<()>
+            .next_call(matching!(_))
+            .returns(Some("1".to_string())),
+        InOptionMock::str::<()>
+            .next_call(matching!(_))
+            .returns(Some("2")),
+        InOptionMock::str::<()>
+            .next_call(matching!(_))
+            .returns(None::<&str>),
+    ));
+    assert_eq!(Some("1"), u.str(""));
+    assert_eq!(Some("2"), u.str(""));
+    assert_eq!(None, u.str(""));
+}
+
+// This test demonstrates that a `T: Clone` bound is not necessary
+// on each_call for `Option<&T>`, since the outer option
+// can be generically reconstructed from the inner borrowed one
+#[test]
+fn in_option_not_clone_can_clone_anyway() {
+    let u: Unimock<AssocType<()>> = Unimock::with_assoc(
+        InOptionMock::not_clone::<()>
+            .each_call(matching!())
+            .returns(Some(clone::Nope)),
+    );
+    assert_eq!(Some(&clone::Nope), <Unimock<_> as InOption>::not_clone(&u));
+    assert_eq!(Some(&clone::Nope), <Unimock<_> as InOption>::not_clone(&u));
+}
+
+#[unimock(api=InResultMock)]
+trait InResult {
+    type X;
+    fn bytes(&self) -> Result<&[u8], clone::Nope>;
+    fn u32_clone(&self) -> Result<&u32, clone::Sure>;
+    fn ok_no_clone(&self, ok: bool) -> Result<&clone::Nope, clone::Sure>;
+    fn err_no_clone(&self) -> Result<&clone::Nope, clone::Nope>;
+}
+
+#[test]
+fn in_result() {
+    let u: Unimock<AssocType<()>> = Unimock::with_assoc((
+        InResultMock::bytes::<()>
+            .next_call(matching!())
+            .returns(Ok(vec![42])),
+        InResultMock::bytes::<()>
+            .next_call(matching!())
+            .returns(Err::<&[u8], _>(clone::Nope)),
+        InResultMock::u32_clone::<()>
+            .each_call(matching!())
+            .returns(Ok(42))
+            .at_least_times(2),
+    ));
+
+    assert_eq!(Ok(vec![42].as_slice()), <Unimock<_> as InResult>::bytes(&u));
+    assert_eq!(Err(clone::Nope), <Unimock<_> as InResult>::bytes(&u));
+    assert_eq!(Ok(&42), <Unimock<_> as InResult>::u32_clone(&u));
+    assert_eq!(Ok(&42), <Unimock<_> as InResult>::u32_clone(&u));
+}
+
+#[test]
+fn in_result_clone_acrobatics() {
+    let u: Unimock<AssocType<()>> = Unimock::with_assoc((
+        InResultMock::ok_no_clone::<()>
+            .each_call(matching!(true))
+            .returns(Ok(clone::Nope)),
+        InResultMock::ok_no_clone::<()>
+            .each_call(matching!(false))
+            .returns(Err::<&clone::Nope, _>(clone::Sure)),
+        InResultMock::err_no_clone::<()>
+            .some_call(matching!()) // note: .each_call is impossible
+            .returns(Err::<&clone::Nope, _>(clone::Nope)),
+    ));
+
+    for _ in 0..3 {
+        assert_eq!(Ok(&clone::Nope), u.ok_no_clone(true));
+        assert_eq!(Err(clone::Sure), u.ok_no_clone(false));
+    }
+
+    assert_eq!(Err(clone::Nope), u.err_no_clone());
+}
+
+#[test]
+#[should_panic(
+    expected = "InResult::ok_no_clone: Expected InResult::ok_no_clone(_) at tests/it/assoc_types.rs:1103 to match exactly 1 call, but it actually matched 2 calls."
+)]
+fn in_result_may_multi_respond_on_ok_no_clone() {
+    let u: Unimock<AssocType<()>> = Unimock::with_assoc(
+        InResultMock::ok_no_clone::<()>
+            .some_call(matching!(_))
+            .returns(Ok(clone::Nope)),
+    );
+
+    assert_eq!(Ok(&clone::Nope), u.ok_no_clone(true));
+    assert_eq!(Ok(&clone::Nope), u.ok_no_clone(true));
+}
+
+#[unimock(api = InVecMock)]
+trait InVec {
+    type X;
+    fn vector(&self) -> Vec<&i32>;
+}
+
+#[test]
+fn in_vec() {
+    let u: Unimock<AssocType<()>> = Unimock::with_assoc(
+        InVecMock::vector::<()>
+            .each_call(matching!())
+            .returns(vec![1, 2, 3]),
+    );
+
+    assert_eq!(vec![&1, &2, &3], u.vector());
+}
+
+#[unimock(api = MixedTupleMock)]
+trait MixedTuple {
+    type X;
+    fn tuple1(&self) -> (&i32,);
+    fn tuple2a(&self) -> (&i32, i32);
+    fn tuple2b(&self) -> (i32, &i32);
+    fn tuple4(&self) -> (&clone::Nope, clone::Nope, &clone::Sure, clone::Sure);
+}
+
+#[test]
+fn mixed_tuple1() {
+    let u: Unimock<AssocType<()>> = Unimock::with_assoc((
+        MixedTupleMock::tuple2a::<()>
+            .next_call(matching!())
+            .returns((1, 2)),
+        MixedTupleMock::tuple2b::<()>
+            .next_call(matching!())
+            .returns((1, 2)),
+    ));
+
+    assert_eq!((&1, 2), u.tuple2a());
+    assert_eq!((1, &2), u.tuple2b());
+}
+
+#[test]
+fn mixed_tuple_clone_combinatorics_once() {
+    let u: Unimock<AssocType<()>> = Unimock::with_assoc(
+        MixedTupleMock::tuple4::<()>
+            .next_call(matching!())
+            .returns((clone::Nope, clone::Nope, clone::Sure, clone::Sure)),
+    );
+
+    assert_eq!(
+        (&clone::Nope, clone::Nope, &clone::Sure, clone::Sure),
+        u.tuple4()
+    );
+}
+
+#[test]
+fn mixed_tuple_clone_combinatorics_many() {
+    let u: Unimock<AssocType<()>> = Unimock::with_assoc(
+        MixedTupleMock::tuple4::<()>
+            .each_call(matching!())
+            .answers(|_| (clone::Nope, clone::Nope, clone::Sure, clone::Sure)),
+    );
+
+    for _ in 0..3 {
+        assert_eq!(
+            (&clone::Nope, clone::Nope, &clone::Sure, clone::Sure),
+            u.tuple4()
+        );
+    }
+}
 
 mod complex {
     use async_trait::async_trait;
     use unimock::*;
 
-    // #[unimock(api=CrazyMock)]
-    // #[async_trait(?Send)]
-    // trait Crazy<'x, T> {
-    //     type Ok;
+    #[unimock(api=CrazyMock)]
+    #[async_trait(?Send)]
+    trait Crazy<'x, T> {
+        type Ok;
 
-    //     type Err;
+        type Err;
 
-    //     async fn thing(&'x self, arg: T) -> Result<Self::Ok, Self::Err>;
-    // }
+        async fn thing(&'x self, arg: T) -> Result<Self::Ok, Self::Err>;
+    }
 
-    // #[tokio::test]
-    // async fn crazy() {
-    //     let u = Unimock::with_assoc(
-    //         CrazyMock::thing::<i32, String>
-    //             .with_types::<u32>()
-    //             .next_call(matching!(666_666))
-    //             .returns(Ok(42)),
-    //     );
+    #[tokio::test]
+    async fn crazy() {
+        let u = Unimock::with_assoc(
+            CrazyMock::thing::<i32, String>
+                .with_types::<u32>()
+                .next_call(matching!(666_666))
+                .returns(Ok(42)),
+        );
 
-    //     assert_eq!(Ok::<_, String>(42), u.thing(666_666u32).await);
-    // }
+        assert_eq!(Ok::<_, String>(42), u.thing(666_666u32).await);
+    }
 
     #[unimock(api=EvenCrazierMock)]
     #[async_trait(?Send)]
@@ -1231,117 +1229,145 @@ mod complex {
 
         assert_eq!(Ok::<_, String>("42"), u.thing2((), &666_666u32).await);
     }
-}
 
-// Recursive expansion of unimock! macro
-// ======================================
+    #[unimock(api=Comb1)]
+    trait Combinations1 {
+        type Input;
+        type Output;
 
-#[async_trait(?Send)]
-trait EvenCrazier<'x, T: Default, Unit = ()>
-where
-    T: ?Sized,
-{
-    type Ok: Into<Self::Err>;
+        fn by_val(self);
+        fn by_ref(&self);
+        fn by_mut(&mut self);
 
-    type Err: std::fmt::Display + 'static;
+        fn by_val_out(self) -> Self::Output;
+        fn by_ref_out(&self) -> Self::Output;
+        fn by_mut_out(&mut self) -> Self::Output;
 
-    async fn thing2(&'x self, other: Unit, arg: &T) -> Result<Self::Ok, Self::Err>;
-}
-#[doc = "Unimock setup module for `EvenCrazier`"]
-#[allow(non_snake_case)]
-mod EvenCrazierMock {
-    #[allow(non_camel_case_types)]
-    #[doc = "Generic mock interface for `EvenCrazier::thing2(other: Unit, arg: &T) -> Result<Ok, Err>`. Get a MockFn instance by calling `with_types()`."]
-    #[allow(unused)]
-    #[::unimock::macro_api::phantom] ////////////////////////// add phantom
-    pub struct thing2<Ok: Into<Err>, Err: std::fmt::Display + 'static>; ////////////////////// assoc types as params
-}
-const _: () = {
-    impl<Ok: Into<Err> + Send +'static, Err: std::fmt::Display + 'static + Send> EvenCrazierMock::thing2<Ok, Err> { //////////////////// assoc types as params with +'static+Send; as args 
-        pub fn with_types<T: Default + 'static + Send, Unit: 'static + Send>( /////////////////////// remove default
-            self,
-        ) -> impl for<'__i> ::unimock::MockFn<
-            Inputs<'__i> = (Unit, &'__i T),
-            Response = ::unimock::output::Owned<Result<Ok, Err>>,
-        >
-        where
-            T: ?Sized,
-        {
-            __Genericthing2(::core::marker::PhantomData, ::core::marker::PhantomData, ::core::marker::PhantomData, ::core::marker::PhantomData)
-        }
+        fn by_val_inp(self, a: Self::Input);
+        fn by_ref_inp(&self, a: Self::Input);
+        fn by_mut_inp(&mut self, a: Self::Input);
+
+        fn by_val_inp_out(self, a: Self::Input) -> Self::Output;
+        fn by_ref_inp_out(&self, a: Self::Input) -> Self::Output;
+        fn by_mut_inp_out(&mut self, a: Self::Input) -> Self::Output;
+
+        // FIXME: 'static bounds for method generics
+        // fn by_val_gen<T>(self);
+        // fn by_ref_gen<T>(&self);
+        // fn by_mut_gen<T>(&mut self);
+
+        // fn by_val_out_gen<T>(self) -> Self::Output;
+        // fn by_ref_out_gen<T>(&self) -> Self::Output;
+        // fn by_mut_out_gen<T>(&mut self) -> Self::Output;
+
+        // fn by_val_inp_gen<T>(self, a: Self::Input);
+        // fn by_ref_inp_gen<T>(&self, a: Self::Input);
+        // fn by_mut_inp_gen<T>(&mut self, a: Self::Input);
+
+        // fn by_val_inp_out_gen<T>(self, a: Self::Input) -> Self::Output;
+        // fn by_ref_inp_out_gen<T>(&self, a: Self::Input) -> Self::Output;
+        // fn by_mut_inp_out_gen<T>(&mut self, a: Self::Input) -> Self::Output;
+
+        // fn by_val_gen_inp<T>(self, b: T);
+        // fn by_ref_gen_inp<T>(&self, b: T);
+        // fn by_mut_gen_inp<T>(&mut self, b: T);
+
+        // fn by_val_out_gen_inp<T>(self, b: T) -> Self::Output;
+        // fn by_ref_out_gen_inp<T>(&self, b: T) -> Self::Output;
+        // fn by_mut_out_gen_inp<T>(&mut self, b: T) -> Self::Output;
+
+        // fn by_val_inp_gen_inp<T>(self, a: Self::Input, b: T);
+        // fn by_ref_inp_gen_inp<T>(&self, a: Self::Input, b: T);
+        // fn by_mut_inp_gen_inp<T>(&mut self, a: Self::Input, b: T);
+
+        // fn by_val_inp_out_gen_inp<T>(self, a: Self::Input, b: T) -> Self::Output;
+        // fn by_ref_inp_out_gen_inp<T>(&self, a: Self::Input, b: T) -> Self::Output;
+        // fn by_mut_inp_out_gen_inp<T>(&mut self, a: Self::Input, b: T) -> Self::Output;
+
+        // fn by_val_gen_out<T>(self) -> T;
+        // fn by_ref_gen_out<T>(&self) -> T;
+        // fn by_mut_gen_out<T>(&mut self) -> T;
+
+        // fn by_val_out_gen_out<T>(self) -> T;
+        // fn by_ref_out_gen_out<T>(&self) -> T;
+        // fn by_mut_out_gen_out<T>(&mut self) -> T;
+
+        // fn by_val_inp_gen_out<T>(self, a: Self::Input) -> T;
+        // fn by_ref_inp_gen_out<T>(&self, a: Self::Input) -> T;
+        // fn by_mut_inp_gen_out<T>(&mut self, a: Self::Input) -> T;
+
+        // fn by_val_inp_out_gen_out<T>(self, a: Self::Input) -> T;
+        // fn by_ref_inp_out_gen_out<T>(&self, a: Self::Input) -> T;
+        // fn by_mut_inp_out_gen_out<T>(&mut self, a: Self::Input) -> T;
     }
-    #[allow(non_camel_case_types)]
-    struct __Genericthing2<T, Unit, Ok, Err>( ///////////// generics + assoc types as args
-        ::core::marker::PhantomData<T>,
-        ::core::marker::PhantomData<Unit>,
-        ::core::marker::PhantomData<Ok>, //////////// add them
-        ::core::marker::PhantomData<Err>, //////////// add them
-    );
 
-    impl<T: Default + 'static + Send, Unit: 'static + Send, Ok: 'static + Send, Err: 'static + Send> ::unimock::MockFn ///////////////// assoc types as args + 'static + Send
-        for __Genericthing2<T, Unit, Ok, Err> ///////////////// generics + assoc types as args
-    where
-        T: ?Sized,
-    {
-        type Inputs<'__i> = (Unit, &'__i T);
-        type Response = ::unimock::output::Owned<Result<Ok, Err>>;
-        type Output<'u> = Self::Response;
-        const NAME: &'static str = "EvenCrazier::thing2";
-        fn debug_inputs((other, arg): &Self::Inputs<'_>) -> String {
-            use ::unimock::macro_api::{NoDebug, ProperDebug};
-            ::unimock::macro_api::format_inputs(&[
-                other.unimock_try_debug(),
-                (*arg).unimock_try_debug(),
-            ])
-        }
+    #[unimock(api=Comb2)]
+    trait Combinations2<T> {
+        type Input;
+        type Output;
+
+        fn by_val(self);
+        fn by_ref(&self);
+        fn by_mut(&mut self);
+
+        fn by_val_out(self) -> Self::Output;
+        fn by_ref_out(&self) -> Self::Output;
+        fn by_mut_out(&mut self) -> Self::Output;
+
+        fn by_val_inp(self, a: Self::Input);
+        fn by_ref_inp(&self, a: Self::Input);
+        fn by_mut_inp(&mut self, a: Self::Input);
+
+        fn by_val_inp_out(self, a: Self::Input) -> Self::Output;
+        fn by_ref_inp_out(&self, a: Self::Input) -> Self::Output;
+        fn by_mut_inp_out(&mut self, a: Self::Input) -> Self::Output;
+
+        fn by_val_gen(self);
+        fn by_ref_gen(&self);
+        fn by_mut_gen(&mut self);
+
+        fn by_val_out_gen(self) -> Self::Output;
+        fn by_ref_out_gen(&self) -> Self::Output;
+        fn by_mut_out_gen(&mut self) -> Self::Output;
+
+        fn by_val_inp_gen(self, a: Self::Input);
+        fn by_ref_inp_gen(&self, a: Self::Input);
+        fn by_mut_inp_gen(&mut self, a: Self::Input);
+
+        fn by_val_inp_out_gen(self, a: Self::Input) -> Self::Output;
+        fn by_ref_inp_out_gen(&self, a: Self::Input) -> Self::Output;
+        fn by_mut_inp_out_gen(&mut self, a: Self::Input) -> Self::Output;
+
+        fn by_val_gen_inp(self, b: T);
+        fn by_ref_gen_inp(&self, b: T);
+        fn by_mut_gen_inp(&mut self, b: T);
+
+        fn by_val_out_gen_inp(self, b: T) -> Self::Output;
+        fn by_ref_out_gen_inp(&self, b: T) -> Self::Output;
+        fn by_mut_out_gen_inp(&mut self, b: T) -> Self::Output;
+
+        fn by_val_inp_gen_inp(self, a: Self::Input, b: T);
+        fn by_ref_inp_gen_inp(&self, a: Self::Input, b: T);
+        fn by_mut_inp_gen_inp(&mut self, a: Self::Input, b: T);
+
+        fn by_val_inp_out_gen_inp(self, a: Self::Input, b: T) -> Self::Output;
+        fn by_ref_inp_out_gen_inp(&self, a: Self::Input, b: T) -> Self::Output;
+        fn by_mut_inp_out_gen_inp(&mut self, a: Self::Input, b: T) -> Self::Output;
+
+        fn by_val_gen_out(self) -> T;
+        fn by_ref_gen_out(&self) -> T;
+        fn by_mut_gen_out(&mut self) -> T;
+
+        fn by_val_out_gen_out(self) -> T;
+        fn by_ref_out_gen_out(&self) -> T;
+        fn by_mut_out_gen_out(&mut self) -> T;
+
+        fn by_val_inp_gen_out(self, a: Self::Input) -> T;
+        fn by_ref_inp_gen_out(&self, a: Self::Input) -> T;
+        fn by_mut_inp_gen_out(&mut self, a: Self::Input) -> T;
+
+        fn by_val_inp_out_gen_out(self, a: Self::Input) -> T;
+        fn by_ref_inp_out_gen_out(&self, a: Self::Input) -> T;
+        fn by_mut_inp_out_gen_out(&mut self, a: Self::Input) -> T;
     }
-    impl<'x, T: Default + 'static + Send, Unit: 'static + Send, Ok: Into<Err> + Send + 'static, Err: std::fmt::Display + 'static + Send> EvenCrazier<'x, T, Unit> /////////////// generics + assoc types as params +'static+Send
-        for ::unimock::Unimock<::unimock::AssocType<Ok, ::unimock::AssocType<Err>>> //////////////// hlist
-    where
-        T: ?Sized,
-    {
-        type Ok = Ok; //////////////// add them
-        type Err = Err; //////////////// add them
-        #[track_caller]
-        #[allow(
-            clippy::let_unit_value,
-            clippy::no_effect_underscore_binding,
-            clippy::shadow_same,
-            clippy::type_complexity,
-            clippy::type_repetition_in_bounds,
-            clippy::used_underscore_binding
-        )]
-        fn thing2<'life0, 'async_trait>(
-            &'x self,
-            other: Unit,
-            arg: &'life0 T,
-        ) -> ::core::pin::Pin<
-            Box<dyn ::core::future::Future<Output = Result<Self::Ok, Self::Err>> + 'async_trait>,
-        >
-        where
-            'life0: 'async_trait,
-            Self: 'async_trait,
-            'x: 'async_trait ////////////// bound
-        {
-            Box::pin(async move {
-                if let ::core::option::Option::Some(__ret) =
-                    ::core::option::Option::None::<Result<Self::Ok, Self::Err>>
-                {
-                    return __ret;
-                }
-                let __self = self;
-                let other = other;
-                let arg = arg;
-                let __ret: Result<Self::Ok, Self::Err> = {
-                    ::unimock::macro_api::eval::<__Genericthing2::<T, Unit, Ok, Err>, _>( ///////////////// generics + assoc types as args
-                        &__self,
-                        (other, arg),
-                    )
-                    .unwrap(&__self)
-                };
-                #[allow(unreachable_code)]
-                __ret
-            })
-        }
-    }
-};
+}

--- a/tests/it/assoc_types.rs
+++ b/tests/it/assoc_types.rs
@@ -1,0 +1,989 @@
+use async_trait::async_trait;
+use unimock::*;
+
+#[test]
+fn noarg_works() {
+    #[unimock(api=NoArgMock)]
+    trait NoArg {
+        type X;
+
+        fn no_arg(&self) -> Self::X;
+    }
+
+    assert_eq!(
+        1_000_000,
+        Unimock::new_with_assoc(
+            NoArgMock::no_arg::<i32>
+                .next_call(matching!())
+                .returns(1_000_000)
+        )
+        .no_arg()
+    );
+}
+
+#[test]
+fn owned_output_works() {
+    #[unimock(api=OwnedMock)]
+    trait Owned {
+        type X;
+
+        fn foo(&self, a: String, b: Self::X) -> Self::X;
+    }
+
+    fn takes_owned<O: Owned<X = String>>(
+        o: &O,
+        a: impl Into<String>,
+        b: impl Into<O::X>,
+    ) -> String {
+        o.foo(a.into(), b.into())
+    }
+
+    assert_eq!(
+        "ab",
+        takes_owned(
+            &Unimock::new_with_assoc(
+                OwnedMock::foo::<String>
+                    .next_call(matching!(_, _))
+                    .answers(|(a, b)| format!("{a}{b}"))
+                    .once()
+            ),
+            "a",
+            "b",
+        )
+    );
+    assert_eq!(
+        "lol",
+        takes_owned(
+            &Unimock::new_with_assoc(OwnedMock::foo::<String>.stub(|each| {
+                each.call(matching!(_, _)).returns("lol");
+            })),
+            "a",
+            "b",
+        )
+    );
+    assert_eq!(
+        "",
+        takes_owned(
+            &Unimock::new_with_assoc(OwnedMock::foo::<String>.stub(|each| {
+                each.call(matching!("a", "b")).returns_default();
+            })),
+            "a",
+            "b",
+        )
+    );
+}
+
+mod exotic_self_types {
+    use super::*;
+    use std::rc::Rc;
+
+    // #[unimock]
+    // trait OwnedSelf {
+    //     type X;
+
+    //     fn foo(self);
+    // }
+
+    #[unimock(api=MutSelfMock)]
+    trait MutSelf {
+        type X;
+
+        fn mut_self(&mut self);
+    }
+
+    #[unimock(api=RcSelfMock)]
+    trait RcSelf {
+        type X;
+
+        fn rc_self(self: Rc<Self>);
+    }
+
+    #[test]
+    fn mut_self() {
+        let mut u: Unimock<AssocType<i32>> = Unimock::new_with_assoc(
+            MutSelfMock::mut_self::<i32>
+                .each_call(matching!())
+                .returns(()),
+        );
+
+        u.mut_self();
+    }
+
+    #[test]
+    fn rc_self() {
+        let deps: Rc<Unimock<AssocType<i32>>> = Rc::new(Unimock::new_with_assoc(
+            RcSelfMock::rc_self::<i32>
+                .each_call(matching!())
+                .returns(()),
+        ));
+
+        deps.rc_self();
+    }
+}
+
+mod exotic_methods {
+    use super::*;
+
+    #[unimock(api=ProvidedMock)]
+    trait Provided {
+        type X: Default;
+
+        fn not_provided(&self);
+        fn provided(&self) -> Self::X {
+            Self::X::default()
+        }
+    }
+
+    #[test]
+    fn test_provided() {
+        let deps = Unimock::new_with_assoc(
+            ProvidedMock::provided::<i32>
+                .each_call(matching!())
+                .returns(42),
+        );
+        assert_eq!(42, deps.provided());
+    }
+
+    // #[unimock]
+    // trait SkipStaticProvided {
+    //     type X;
+
+    //     fn skip1() {}
+    //     fn skip2(arg: i32) -> i32 {
+    //         arg
+    //     }
+    // }
+}
+
+mod referenced {
+    use super::*;
+
+    #[unimock(api=ReferencedMock)]
+    trait Referenced {
+        type X;
+
+        fn foo(&self, a: &str) -> &str;
+        fn bar(&self, a: &str, b: &str) -> &str;
+    }
+
+    fn takes_referenced<'s, 'x, R: Referenced<X = &'x str>>(r: &'s R, a: R::X) -> &'s str {
+        r.foo(a)
+    }
+
+    #[test]
+    fn referenced_with_static_return_value_works() {
+        let u = Unimock::new_with_assoc(ReferencedMock::foo::<&str>.stub(|each| {
+            each.call(matching!("a")).returns("answer".to_string());
+        }));
+        assert_eq!("answer", takes_referenced(&u, "a",));
+    }
+
+    #[test]
+    fn referenced_with_default_return_value_works() {
+        let u = Unimock::new_with_assoc(ReferencedMock::foo::<&str>.stub(|each| {
+            each.call(matching!("Æ")).panics("Should not be called");
+            each.call(matching!("a")).returns(String::new());
+        }));
+        assert_eq!("", takes_referenced(&u, "a",));
+    }
+
+    #[test]
+    fn referenced_with_static_ref_works() {
+        let u = Unimock::new_with_assoc(ReferencedMock::foo::<&str>.stub(|each| {
+            each.call(matching!("a")).returns("foobar");
+        }));
+        assert_eq!("foobar", takes_referenced(&u, "a",));
+    }
+}
+
+mod no_clone_return {
+    use unimock::*;
+
+    #[derive(Debug, PartialEq)]
+    pub struct NoClone(i32);
+
+    #[unimock(api=FooMock)]
+    trait Foo {
+        type X;
+
+        fn foo(&self) -> Self::X;
+    }
+
+    #[test]
+    fn test_no_clone_return() {
+        let u = Unimock::new_with_assoc(
+            FooMock::foo::<NoClone>
+                .some_call(matching!())
+                .returns(NoClone(55)),
+        );
+        assert_eq!(NoClone(55), u.foo());
+    }
+}
+
+mod each_call_implicitly_clones {
+    use unimock::*;
+
+    #[unimock(api=FooMock)]
+    trait Foo {
+        type X;
+
+        fn foo(&self) -> Self::X;
+    }
+
+    #[test]
+    fn each_call_implicit_clone() {
+        let u = Unimock::new_with_assoc(FooMock::foo::<i32>.each_call(matching!()).returns(55));
+        assert_eq!(55, u.foo());
+        assert_eq!(55, u.foo());
+    }
+}
+
+#[unimock(api=SingleArgMock)]
+trait SingleArg {
+    type X;
+
+    fn method1<'i>(&'i self, a: &'i str) -> &'i Self::X;
+}
+
+#[unimock(api=MultiArgMock)]
+trait MultiArg {
+    type X;
+
+    fn method2(&self, a: &str, b: &str) -> &Self::X;
+}
+
+#[test]
+fn test_multiple() {
+    fn takes_single_multi(
+        t: &(impl SingleArg<X = &'static str> + MultiArg<X = &'static str>),
+    ) -> &str {
+        let tmp = t.method1("b");
+        t.method2(tmp, tmp)
+    }
+
+    let u = Unimock::new_with_assoc((
+        SingleArgMock::method1::<&'static str>.stub(|each| {
+            each.call(matching!("b")).returns("B").once();
+        }),
+        MultiArgMock::method2::<&'static str>.stub(|each| {
+            each.call(matching!("a", _)).panics("should not call this");
+            each.call(matching!("B", "B")).returns("success").once();
+        }),
+    ));
+    assert_eq!("success", takes_single_multi(&u));
+}
+
+mod no_debug {
+    use super::*;
+
+    pub enum PrimitiveEnum {
+        Foo,
+        Bar,
+    }
+
+    #[unimock(api=VeryPrimitiveMock)]
+    trait VeryPrimitive {
+        type X;
+
+        fn primitive(&self, a: PrimitiveEnum, b: Self::X) -> PrimitiveEnum;
+    }
+
+    #[test]
+    fn can_match_a_non_debug_argument() {
+        match Unimock::new_with_assoc(VeryPrimitiveMock::primitive::<&str>.stub(|each| {
+            each.call(matching!(PrimitiveEnum::Bar, _))
+                .answers(|_| PrimitiveEnum::Foo);
+        }))
+        .primitive(PrimitiveEnum::Bar, "")
+        {
+            PrimitiveEnum::Foo => {}
+            PrimitiveEnum::Bar => panic!(),
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "VeryPrimitive::primitive(?, ?): No matching call patterns.")]
+    fn should_format_non_debug_input_with_a_question_mark() {
+        Unimock::new_with_assoc(VeryPrimitiveMock::primitive::<&str>.stub(|each| {
+            each.call(matching!(PrimitiveEnum::Bar, _))
+                .answers(|_| PrimitiveEnum::Foo);
+        }))
+        .primitive(PrimitiveEnum::Foo, "");
+    }
+}
+
+#[test]
+fn should_debug_reference_to_debug_implementing_type() {
+    #[derive(Debug)]
+    pub enum DebugEnum {}
+
+    // #[unimock]
+    // trait VeryPrimitiveRefZero {
+    //     type X;
+
+    //     fn primitive_ref(&self, a: DebugEnum) -> DebugEnum;
+    // }
+
+    // #[unimock]
+    // trait VeryPrimitiveRefOnce {
+    //     type X;
+
+    //     fn primitive_ref(&self, a: &DebugEnum) -> DebugEnum;
+    // }
+
+    // #[unimock]
+    // trait VeryPrimitiveRefTwice {
+    //     type X;
+
+    //     fn primitive_ref(&self, a: &&DebugEnum) -> DebugEnum;
+    // }
+}
+
+#[test]
+fn should_be_able_to_borrow_a_returns_value() {
+    #[derive(Eq, PartialEq, Debug, Clone)]
+    pub struct Ret<T>(T);
+
+    #[unimock(api=BorrowsRetMock)]
+    trait BorrowsRet {
+        type X;
+
+        fn borrows_ret(&self) -> &Ret<Self::X>;
+    }
+
+    assert_eq!(
+        &Ret(42),
+        Unimock::new_with_assoc(
+            BorrowsRetMock::borrows_ret::<i32>
+                .each_call(matching!())
+                .returns(&Ret(42))
+        )
+        .borrows_ret()
+    );
+}
+
+#[test]
+fn various_borrowing() {
+    #[unimock(api=BorrowingMock)]
+    trait Borrowing {
+        type X;
+
+        fn borrow(&self, input: Self::X) -> &Self::X;
+        fn borrow_static(&self) -> &'static Self::X;
+    }
+    fn get_str<'s, B: Borrowing<X = String>>(t: &'s B, input: &str) -> &'s str {
+        t.borrow(input.to_string()).as_str()
+    }
+
+    let u = Unimock::new_with_assoc(
+        BorrowingMock::borrow::<String>
+            .next_call(matching!(_))
+            .returns("foo".to_string())
+            .once(),
+    );
+    assert_eq!("foo", get_str(&u, ""));
+    let u = Unimock::new_with_assoc(
+        BorrowingMock::borrow::<String>
+            .next_call(matching!(_))
+            .returns("foo".to_string())
+            .once(),
+    );
+    assert_eq!("foo", get_str(&u, ""));
+    let u = Unimock::new_with_assoc(
+        BorrowingMock::borrow::<String>
+            .next_call(matching!(_))
+            .answers(|input| format!("{input}{input}"))
+            .once(),
+    );
+    assert_eq!("yoyo", get_str(&u, "yo"));
+    let u: Unimock<AssocType<String>> = Unimock::new_with_assoc(
+        BorrowingMock::borrow_static::<String>
+            .next_call(matching!(_))
+            .answers_leaked_ref(|_| format!("yoyoyo"))
+            .once(),
+    );
+    assert_eq!("yoyoyo", u.borrow_static());
+}
+
+mod custom_api_module {
+    use unimock::*;
+
+    pub struct MyType;
+
+    #[unimock(api=FakeSingle)]
+    trait Single {
+        type X;
+
+        fn func(&self) -> &Self::X;
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "Single::func: Expected Single::func(_) at tests/it/assoc_types.rs:427 to match exactly 1 call, but it actually matched no calls.\nMock for Single::func was never called. Dead mocks should be removed."
+    )]
+    fn test_without_module() {
+        Unimock::<AssocType<MyType>>::new_with_assoc(
+            FakeSingle::func::<MyType>
+                .next_call(matching!(_))
+                .returns(MyType)
+                .once(),
+        );
+    }
+}
+
+mod flattened_module {
+    mod assoc_types {
+        use unimock::*;
+
+        #[unimock(api=[Foo, Bar])]
+        trait WithUnpackedModule {
+            type X;
+
+            fn foo(&self, input: String) -> i32;
+            fn bar(&self);
+        }
+
+        #[test]
+        fn test_unpacked_module() {
+            let _ = Foo::<i32>.each_call(matching!(_)).returns(33);
+            let _ = Bar::<()>.each_call(matching!(_)).returns(());
+        }
+    }
+
+    mod generics {
+        use unimock::*;
+
+        #[unimock(api=[Foo, Bar])]
+        trait UnpackedGenerics<T> {
+            type X;
+
+            fn foo(&self, input: String) -> T;
+            fn bar(&self, input: &T);
+        }
+    }
+
+    mod exports {
+        mod inner {
+            use unimock::*;
+            #[unimock(api=[FooMock])]
+            pub trait Trait {
+                type X;
+
+                fn foo(&self);
+            }
+        }
+
+        #[test]
+        fn test_inner() {
+            use unimock::*;
+            let _ = inner::FooMock::<i32>.each_call(matching!()).returns(());
+        }
+    }
+}
+
+#[unimock(api=AsyncMock)]
+#[async_trait(?Send)]
+trait Async {
+    type X;
+
+    async fn func(&self, arg: Self::X) -> String;
+}
+
+#[tokio::test]
+async fn test_async_trait() {
+    async fn takes_async<A: Async>(a: &A, arg: A::X) -> String {
+        a.func(arg).await
+    }
+
+    assert_eq!(
+        "42",
+        takes_async(
+            &Unimock::new_with_assoc(AsyncMock::func::<i32>.stub(|each| {
+                each.call(matching!(_)).returns("42");
+            })),
+            21
+        )
+        .await
+    );
+}
+
+use std::borrow::Cow;
+
+#[unimock(api=CowBasedMock)]
+trait CowBased {
+    type X: ?Sized + ToOwned;
+
+    fn func(&self, arg: Cow<'static, Self::X>) -> Cow<'static, Self::X>;
+}
+
+#[test]
+fn test_cow() {
+    fn takes<C: CowBased>(t: &C, arg: Cow<'static, C::X>) -> Cow<'static, C::X> {
+        t.func(arg)
+    }
+
+    assert_eq!(
+        "output",
+        takes(
+            &Unimock::new_with_assoc(CowBasedMock::func::<str>.stub(|each| {
+                each.call(matching! {("input") | ("foo")}).returns("output");
+            })),
+            "input".into()
+        )
+    )
+}
+
+#[test]
+fn borrow_intricate_lifetimes() {
+    pub struct I<'s>(std::marker::PhantomData<&'s ()>);
+    pub struct O<'s>(&'s String);
+
+    #[unimock(api = IntricateMock)]
+    trait Intricate {
+        type X;
+
+        fn foo<'s, 't>(&'s self, inp: &'t I<'s>) -> &'s O<'t>;
+    }
+
+    fn takes_intricate(i: &impl Intricate) {
+        i.foo(&I(std::marker::PhantomData));
+    }
+
+    let u: Unimock<AssocType<()>> = Unimock::new_with_assoc(
+        IntricateMock::foo::<()>
+            .next_call(matching!(I(_)))
+            .returns(O(Box::leak(Box::new("leaked".to_string())))),
+    );
+
+    takes_intricate(&u);
+}
+
+#[test]
+fn clause_helpers() {
+    #[unimock(api=FooMock)]
+    trait Foo {
+        type X;
+
+        fn m1(&self) -> Self::X;
+    }
+
+    #[unimock(api=BarMock)]
+    trait Bar {
+        type X;
+
+        fn m2(&self) -> Self::X;
+    }
+    #[unimock(api=BazMock)]
+    trait Baz {
+        type X;
+
+        fn m3(&self) -> Self::X;
+    }
+
+    fn setup_foo_bar() -> impl Clause {
+        (
+            FooMock::m1::<i32>.some_call(matching!(_)).returns(1),
+            BarMock::m2::<i32>.each_call(matching!(_)).returns(2),
+        )
+    }
+
+    let deps: Unimock<AssocType<i32>> = Unimock::new_with_assoc((
+        setup_foo_bar(),
+        BazMock::m3::<i32>.each_call(matching!(_)).returns(3),
+    ));
+    assert_eq!(6, deps.m1() + deps.m2() + deps.m3());
+}
+
+mod responders_in_series {
+    use super::*;
+
+    #[unimock(api=SeriesMock)]
+    trait Series {
+        type X;
+
+        fn series(&self) -> Self::X;
+    }
+
+    fn clause() -> impl Clause {
+        SeriesMock::series::<i32>
+            .each_call(matching!())
+            .returns(1)
+            .once()
+            .then()
+            .returns(2)
+            .n_times(2)
+            .then()
+            .returns(3)
+            .at_least_times(1)
+    }
+
+    #[test]
+    fn responder_series_should_work() {
+        let a = Unimock::new_with_assoc(clause());
+
+        assert_eq!(1, a.series());
+        assert_eq!(2, a.series());
+        assert_eq!(2, a.series());
+        // it will continue to return 3:
+        assert_eq!(3, a.series());
+        assert_eq!(3, a.series());
+        assert_eq!(3, a.series());
+        assert_eq!(3, a.series());
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "Series::series: Expected Series::series() at tests/it/assoc_types.rs:609 to match at least 4 calls, but it actually matched 2 calls."
+    )]
+    fn series_not_fully_generated_should_panic() {
+        let b = Unimock::new_with_assoc(clause());
+
+        assert_eq!(1, b.series());
+        assert_eq!(2, b.series());
+
+        // Exact repetition was defined to be 4 (the last responder is not exactly quantified), but it contained a `.then` call so minimum 1.
+    }
+}
+
+#[unimock(api=BorrowStaticMock)]
+trait BorrowStatic {
+    type X;
+
+    fn static_str(&self, arg: Self::X) -> &'static str;
+}
+
+#[test]
+fn borrow_static_should_work_with_returns_static() {
+    assert_eq!(
+        "foo",
+        Unimock::new_with_assoc(
+            BorrowStaticMock::static_str::<i32>
+                .next_call(matching!(_))
+                .returns("foo")
+        )
+        .static_str(33)
+    );
+}
+
+mod async_argument_borrowing {
+    use super::*;
+
+    #[unimock(api=BorrowParamMock)]
+    #[async_trait(?Send)]
+    trait BorrowParam {
+        type X;
+
+        async fn borrow_param<'a>(&self, arg: &'a Self::X) -> &'a Self::X;
+    }
+
+    #[tokio::test]
+    async fn test_argument_borrowing() {
+        let unimock = Unimock::new_with_assoc(
+            BorrowParamMock::borrow_param::<&str>
+                .each_call(matching!(_))
+                .returns(&"foobar"),
+        );
+
+        assert_eq!(&"foobar", unimock.borrow_param(&"input").await);
+    }
+
+    #[tokio::test]
+    async fn test_argument_borrowing_works() {
+        let unimock = Unimock::new_with_assoc(
+            BorrowParamMock::borrow_param::<&str>
+                .each_call(matching!(_))
+                .returns(&"foobar"),
+        );
+
+        unimock.borrow_param(&"input").await;
+    }
+}
+
+mod lifetime_constrained_output_type {
+    use super::*;
+
+    #[derive(Clone)]
+    pub struct Borrowing1<'a, T: ?Sized>(&'a T);
+
+    #[derive(Clone)]
+    pub struct Borrowing2<'a, 'b, T: ?Sized>(&'a T, &'b T);
+
+    #[unimock(api=BorrowSyncMock)]
+    trait BorrowSync {
+        type X: ?Sized;
+
+        fn borrow_sync_elided(&self) -> Borrowing1<'_, Self::X>;
+        fn borrow_sync_explicit(&self) -> Borrowing1<'_, Self::X>;
+        fn borrow_sync_explicit2<'a, 'b>(&'a self, arg: &'b str) -> Borrowing2<'a, 'b, Self::X>;
+    }
+
+    // #[unimock]
+    // #[async_trait]
+    // trait BorrowAsync {
+    //     type X;
+
+    //     async fn borrow_async_elided(&self) -> Borrowing1<'_>;
+    //     async fn borrow_async_explicit<'a>(&'a self) -> Borrowing1<'a>;
+    //     async fn borrow_async_explicit2<'a, 'b>(&'a self, arg: &'b str) -> Borrowing2<'a, 'b>;
+    // }
+
+    #[test]
+    fn test_borrow() {
+        let deps = Unimock::new_with_assoc(
+            BorrowSyncMock::borrow_sync_explicit2::<&str>
+                .some_call(matching!("foobar"))
+                .returns(Borrowing2(&"a", &"b")),
+        );
+
+        let result: Borrowing2<'_, '_, &str> = deps.borrow_sync_explicit2("foobar");
+        assert_eq!(result.0, &"a");
+        assert_eq!(result.1, &"b");
+    }
+
+    #[test]
+    fn test_borrow_sized() {
+        let deps = Unimock::new_with_assoc(
+            BorrowSyncMock::borrow_sync_explicit2::<str>
+                .some_call(matching!("foobar"))
+                .returns(Borrowing2("a", "b")),
+        );
+
+        let result: Borrowing2<'_, '_, str> = deps.borrow_sync_explicit2("foobar");
+        assert_eq!(result.0, "a");
+        assert_eq!(result.1, "b");
+    }
+}
+
+mod slice_matching {
+    use std::vec;
+
+    use super::*;
+
+    #[unimock(api = Mock)]
+    trait Trait {
+        type X;
+
+        type Y;
+
+        fn vec_of_i32(&self, a: Vec<Self::X>);
+        fn two_vec_of_i32(&self, a: Vec<Self::X>, b: Vec<Self::X>);
+        fn vec_of_string(&self, a: Vec<Self::Y>);
+    }
+
+    #[test]
+    fn vec_of_strings() {
+        Unimock::<AssocType<_, AssocType<String>>>::new_with_assoc(
+            Mock::vec_of_i32::<i32, String>
+                .next_call(matching!([1, 2]))
+                .returns(()),
+        )
+        .vec_of_i32(vec![1, 2]);
+        Unimock::<AssocType<_, AssocType<String>>>::new_with_assoc(
+            Mock::two_vec_of_i32::<i32, String>
+                .next_call(matching!([1, 2], [3, 4]))
+                .returns(()),
+        )
+        .two_vec_of_i32(vec![1, 2], vec![3, 4]);
+        Unimock::<AssocType<i32, AssocType<_>>>::new_with_assoc(
+            Mock::vec_of_string::<i32, String>
+                .next_call(matching!(([a, b]) if a == "1" && b == "2"))
+                .returns(()),
+        )
+        .vec_of_string(vec!["1".to_string(), "2".to_string()]);
+    }
+}
+
+#[test]
+fn eval_name_clash() {
+    #[unimock(api = Mock, unmock_with=[unmock])]
+    trait Trait {
+        type X;
+
+        fn tralala(&self, eval: Self::X);
+    }
+
+    fn unmock<X>(_: &impl std::any::Any, _: X) {}
+}
+
+#[test]
+fn fn_cfg_attrs() {
+    #[unimock(api = TraitMock)]
+    trait Trait {
+        type X;
+
+        fn a(&self) -> Self::X;
+
+        #[cfg(feature = "always-disabled")]
+        fn b(&self) -> NonExistentType;
+    }
+
+    let u = Unimock::new_with_assoc(TraitMock::a::<i32>.next_call(matching!()).returns(0));
+    assert_eq!(0, u.a());
+}
+
+use unimock::*;
+
+use std::fmt::Debug;
+
+mod output {
+    use super::*;
+
+    #[unimock(api=GenericOutputMock)]
+    trait GenericOutput<T> {
+        type X;
+        fn generic_output(&self) -> T;
+    }
+
+    #[test]
+    fn test_generic_return() {
+        let deps: Unimock<AssocType<String>> = Unimock::new_with_assoc(
+            GenericOutputMock::generic_output::<String>
+                .with_types::<String>()
+                .each_call(matching!())
+                .returns("success".to_string()),
+        );
+
+        let output = <Unimock<_> as GenericOutput<String>>::generic_output(&deps);
+        assert_eq!("success", output);
+
+        // let output = <Unimock as GenericOutput<i32>>::generic_output(&deps);
+        // assert_eq!(42, output);
+    }
+}
+
+mod param {
+    use super::*;
+
+    #[unimock(api=GenericParamMock)]
+    trait GenericParam<T> {
+        type X;
+        fn generic_param(&self, param: T) -> &'static str;
+    }
+
+    #[test]
+    fn test_generic_param() {
+        let deps: Unimock<AssocType<i32>> = Unimock::new_with_assoc((
+            GenericParamMock::generic_param::<i32>
+                .with_types::<&'static str>()
+                .each_call(matching!("foobar"))
+                .returns("a string"),
+            GenericParamMock::generic_param::<i32>
+                .with_types::<i32>()
+                .each_call(matching!(42))
+                .returns("a number"),
+        ));
+
+        assert_eq!("a string", deps.generic_param("foobar"));
+        assert_eq!("a number", deps.generic_param(42_i32));
+    }
+
+    #[test]
+    #[should_panic(
+        // Since the generic parameter has no Debug bound, we cannot see the parameter:
+        expected = "GenericParam::generic_param(?): No matching call patterns."
+    )]
+    fn test_generic_param_panic_no_debug() {
+        let deps: Unimock<AssocType<i32>> = Unimock::new_with_assoc(
+            GenericParamMock::generic_param::<i32>
+                .with_types::<i32>()
+                .each_call(matching!(1337))
+                .returns("a number"),
+        );
+
+        deps.generic_param(42_i32);
+    }
+
+    #[unimock(api=GenericParamDebugMock)]
+    trait GenericParamDebug<T: Debug> {
+        type X;
+        fn generic_param_debug(&self, param: T) -> &'static str;
+    }
+
+    #[test]
+    #[should_panic(
+        // When it has a debug bound, we should see it:
+        expected = "GenericParamDebug::generic_param_debug(42): No matching call patterns."
+    )]
+    fn test_generic_param_panic_debug() {
+        let deps: Unimock<AssocType<i32>> = Unimock::new_with_assoc(
+            GenericParamDebugMock::generic_param_debug::<i32>
+                .with_types::<i32>()
+                .each_call(matching!(1337))
+                .returns("a number"),
+        );
+
+        deps.generic_param_debug(42_i32);
+    }
+}
+
+mod combined {
+    use super::*;
+
+    // #[unimock]
+    // trait GenericBounds<I: Debug, O: Clone> {
+    //     type X;
+    //     fn generic_bounds(&self, param: I) -> O;
+    // }
+
+    // #[unimock]
+    // trait GenericWhereBounds<I, O>
+    // where
+    //     I: Debug,
+    //     O: Clone,
+    // {
+    //     type X;
+    //     fn generic_where_bounds(&self, param: I) -> O;
+    // }
+}
+
+mod async_generic {
+    use super::*;
+
+    // #[unimock]
+    // #[async_trait::async_trait(?Send)]
+    // trait AsyncTraitGenericBounds<I: Debug, O: Clone> {
+    //     type X;
+    //     async fn generic_bounds(&self, param: I) -> O;
+    // }
+}
+
+mod generic_without_module {
+    use super::*;
+
+    #[unimock(api=[Func])]
+    trait WithModule<T: Debug> {
+        type X;
+        fn func(&self) -> T;
+    }
+
+    #[test]
+    fn mock() {
+        Func::<i32>
+            .with_types::<String>()
+            .each_call(matching!())
+            .returns("".to_string());
+    }
+}
+
+mod generic_with_unmock {
+    use super::*;
+
+    // #[unimock(unmock_with=[gen_default(self)])]
+    // trait UnmockMe<T: Default> {
+    //     type X;
+    //     fn unmock_me(&self) -> T;
+    // }
+
+    // #[unimock(unmock_with=[gen_default(self)])]
+    // trait UnmockMeWhere<T>
+    // where
+    //     T: Default,
+    // {
+    //     type X;
+    //     fn unmock_me_where(&self) -> T;
+    // }
+
+    fn gen_default<D, T: Default>(_: &D) -> T {
+        T::default()
+    }
+}

--- a/tests/it/assoc_types.rs
+++ b/tests/it/assoc_types.rs
@@ -830,23 +830,30 @@ mod output {
     #[unimock(api=GenericOutputMock)]
     trait GenericOutput<T> {
         type X;
-        fn generic_output(&self) -> T;
+        fn generic_output(&self) -> (T, Self::X);
     }
 
     #[test]
     fn test_generic_return() {
-        let deps: Unimock<AssocType<String>> = Unimock::with_assoc(
-            GenericOutputMock::generic_output::<String>
+        let deps = Unimock::with_assoc(
+            GenericOutputMock::generic_output::<i32>
                 .with_types::<String>()
                 .each_call(matching!())
-                .returns("success".to_string()),
+                .returns(("success".to_string(), 42)),
         );
 
         let output = <Unimock<_> as GenericOutput<String>>::generic_output(&deps);
-        assert_eq!("success", output);
+        assert_eq!(("success".to_string(), 42), output);
 
-        // let output = <Unimock as GenericOutput<i32>>::generic_output(&deps);
-        // assert_eq!(42, output);
+        let deps = Unimock::with_assoc(
+            GenericOutputMock::generic_output::<String>
+                .with_types::<i32>()
+                .each_call(matching!())
+                .returns((42, "success".to_string())),
+        );
+
+        let output = <Unimock<_> as GenericOutput<i32>>::generic_output(&deps);
+        assert_eq!((42, "success".to_string()), output);
     }
 }
 
@@ -1095,7 +1102,7 @@ fn in_result_clone_acrobatics() {
 
 #[test]
 #[should_panic(
-    expected = "InResult::ok_no_clone: Expected InResult::ok_no_clone(_) at tests/it/assoc_types.rs:1103 to match exactly 1 call, but it actually matched 2 calls."
+    expected = "InResult::ok_no_clone: Expected InResult::ok_no_clone(_) at tests/it/assoc_types.rs:1110 to match exactly 1 call, but it actually matched 2 calls."
 )]
 fn in_result_may_multi_respond_on_ok_no_clone() {
     let u: Unimock<AssocType<()>> = Unimock::with_assoc(

--- a/tests/it/assoc_types.rs
+++ b/tests/it/assoc_types.rs
@@ -852,6 +852,7 @@ mod output {
 
 mod param {
     use super::*;
+    use std::fmt::Debug;
 
     #[unimock(api=GenericParamMock)]
     trait GenericParam<T> {
@@ -950,6 +951,7 @@ mod async_generic {
 
 mod generic_without_module {
     use super::*;
+    use std::fmt::Debug;
 
     #[unimock(api=[Func])]
     trait WithModule<T: Debug> {
@@ -1095,7 +1097,7 @@ fn in_result_clone_acrobatics() {
 
 #[test]
 #[should_panic(
-    expected = "InResult::ok_no_clone: Expected InResult::ok_no_clone(_) at tests/it/assoc_types.rs:1108 to match exactly 1 call, but it actually matched 2 calls."
+    expected = "InResult::ok_no_clone: Expected InResult::ok_no_clone(_) at tests/it/assoc_types.rs:1105 to match exactly 1 call, but it actually matched 2 calls."
 )]
 fn in_result_may_multi_respond_on_ok_no_clone() {
     let u: Unimock<AssocType<()>> = Unimock::with_assoc(

--- a/tests/it/assoc_types.rs
+++ b/tests/it/assoc_types.rs
@@ -1,1211 +1,1211 @@
 use async_trait::async_trait;
 use unimock::*;
 
-#[test]
-fn noarg_works() {
-    #[unimock(api=NoArgMock)]
-    trait NoArg {
-        type X;
-
-        fn no_arg(&self) -> Self::X;
-    }
-
-    assert_eq!(
-        1_000_000,
-        Unimock::with_assoc(
-            NoArgMock::no_arg::<i32>
-                .next_call(matching!())
-                .returns(1_000_000)
-        )
-        .no_arg()
-    );
-}
-
-#[test]
-fn owned_output_works() {
-    #[unimock(api=OwnedMock)]
-    trait Owned {
-        type X;
-
-        fn foo(&self, a: String, b: Self::X) -> Self::X;
-    }
-
-    fn takes_owned<O: Owned<X = String>>(
-        o: &O,
-        a: impl Into<String>,
-        b: impl Into<O::X>,
-    ) -> String {
-        o.foo(a.into(), b.into())
-    }
-
-    assert_eq!(
-        "ab",
-        takes_owned(
-            &Unimock::with_assoc(
-                OwnedMock::foo::<String>
-                    .next_call(matching!(_, _))
-                    .answers(|(a, b)| format!("{a}{b}"))
-                    .once()
-            ),
-            "a",
-            "b",
-        )
-    );
-    assert_eq!(
-        "lol",
-        takes_owned(
-            &Unimock::with_assoc(OwnedMock::foo::<String>.stub(|each| {
-                each.call(matching!(_, _)).returns("lol");
-            })),
-            "a",
-            "b",
-        )
-    );
-    assert_eq!(
-        "",
-        takes_owned(
-            &Unimock::with_assoc(OwnedMock::foo::<String>.stub(|each| {
-                each.call(matching!("a", "b")).returns_default();
-            })),
-            "a",
-            "b",
-        )
-    );
-}
-
-mod exotic_self_types {
-    use super::*;
-    use std::rc::Rc;
-
-    #[unimock(api=OwnedSelfMock)]
-    trait OwnedSelf {
-        type X;
-
-        fn foo(self);
-    }
-
-    #[unimock(api=MutSelfMock)]
-    trait MutSelf {
-        type X;
-
-        fn mut_self(&mut self);
-    }
-
-    #[unimock(api=RcSelfMock)]
-    trait RcSelf {
-        type X;
-
-        fn rc_self(self: Rc<Self>);
-    }
-
-    #[test]
-    fn mut_self() {
-        let mut u: Unimock<AssocType<i32>> = Unimock::with_assoc(
-            MutSelfMock::mut_self::<i32>
-                .each_call(matching!())
-                .returns(()),
-        );
-
-        u.mut_self();
-    }
-
-    #[test]
-    fn rc_self() {
-        let deps: Rc<Unimock<AssocType<i32>>> = Rc::new(Unimock::with_assoc(
-            RcSelfMock::rc_self::<i32>
-                .each_call(matching!())
-                .returns(()),
-        ));
-
-        deps.rc_self();
-    }
-}
-
-mod exotic_methods {
-    use super::*;
-
-    #[unimock(api=ProvidedMock)]
-    trait Provided {
-        type X: Default;
-
-        fn not_provided(&self);
-        fn provided(&self) -> Self::X {
-            Self::X::default()
-        }
-    }
-
-    #[test]
-    fn test_provided() {
-        let deps = Unimock::with_assoc(
-            ProvidedMock::provided::<i32>
-                .each_call(matching!())
-                .returns(42),
-        );
-        assert_eq!(42, deps.provided());
-    }
-
-    #[unimock]
-    trait SkipStaticProvided {
-        type X;
-
-        fn skip1() {}
-        fn skip2(arg: i32) -> i32 {
-            arg
-        }
-    }
-}
-
-mod referenced {
-    use super::*;
-
-    #[unimock(api=ReferencedMock)]
-    trait Referenced {
-        type X;
-
-        fn foo(&self, a: &str) -> &str;
-        fn bar(&self, a: &str, b: &str) -> &str;
-    }
-
-    fn takes_referenced<'s, 'x, R: Referenced<X = &'x str>>(r: &'s R, a: R::X) -> &'s str {
-        r.foo(a)
-    }
-
-    #[test]
-    fn referenced_with_static_return_value_works() {
-        let u = Unimock::with_assoc(ReferencedMock::foo::<&str>.stub(|each| {
-            each.call(matching!("a")).returns("answer".to_string());
-        }));
-        assert_eq!("answer", takes_referenced(&u, "a",));
-    }
-
-    #[test]
-    fn referenced_with_default_return_value_works() {
-        let u = Unimock::with_assoc(ReferencedMock::foo::<&str>.stub(|each| {
-            each.call(matching!("Æ")).panics("Should not be called");
-            each.call(matching!("a")).returns(String::new());
-        }));
-        assert_eq!("", takes_referenced(&u, "a",));
-    }
-
-    #[test]
-    fn referenced_with_static_ref_works() {
-        let u = Unimock::with_assoc(ReferencedMock::foo::<&str>.stub(|each| {
-            each.call(matching!("a")).returns("foobar");
-        }));
-        assert_eq!("foobar", takes_referenced(&u, "a",));
-    }
-}
-
-mod no_clone_return {
-    use unimock::*;
-
-    #[derive(Debug, PartialEq)]
-    pub struct NoClone(i32);
-
-    #[unimock(api=FooMock)]
-    trait Foo {
-        type X;
-
-        fn foo(&self) -> Self::X;
-    }
-
-    #[test]
-    fn test_no_clone_return() {
-        let u = Unimock::with_assoc(
-            FooMock::foo::<NoClone>
-                .some_call(matching!())
-                .returns(NoClone(55)),
-        );
-        assert_eq!(NoClone(55), u.foo());
-    }
-}
-
-mod each_call_implicitly_clones {
-    use unimock::*;
-
-    #[unimock(api=FooMock)]
-    trait Foo {
-        type X;
-
-        fn foo(&self) -> Self::X;
-    }
-
-    #[test]
-    fn each_call_implicit_clone() {
-        let u = Unimock::with_assoc(FooMock::foo::<i32>.each_call(matching!()).returns(55));
-        assert_eq!(55, u.foo());
-        assert_eq!(55, u.foo());
-    }
-}
-
-#[unimock(api=SingleArgMock)]
-trait SingleArg {
-    type X;
-
-    fn method1<'i>(&'i self, a: &'i str) -> &'i Self::X;
-}
-
-#[unimock(api=MultiArgMock)]
-trait MultiArg {
-    type X;
-
-    fn method2(&self, a: &str, b: &str) -> &Self::X;
-}
-
-#[test]
-fn test_multiple() {
-    fn takes_single_multi(
-        t: &(impl SingleArg<X = &'static str> + MultiArg<X = &'static str>),
-    ) -> &str {
-        let tmp = t.method1("b");
-        t.method2(tmp, tmp)
-    }
-
-    let u = Unimock::with_assoc((
-        SingleArgMock::method1::<&'static str>.stub(|each| {
-            each.call(matching!("b")).returns("B").once();
-        }),
-        MultiArgMock::method2::<&'static str>.stub(|each| {
-            each.call(matching!("a", _)).panics("should not call this");
-            each.call(matching!("B", "B")).returns("success").once();
-        }),
-    ));
-    assert_eq!("success", takes_single_multi(&u));
-}
-
-mod no_debug {
-    use super::*;
-
-    pub enum PrimitiveEnum {
-        Foo,
-        Bar,
-    }
-
-    #[unimock(api=VeryPrimitiveMock)]
-    trait VeryPrimitive {
-        type X;
-
-        fn primitive(&self, a: PrimitiveEnum, b: Self::X) -> PrimitiveEnum;
-    }
-
-    #[test]
-    fn can_match_a_non_debug_argument() {
-        match Unimock::with_assoc(VeryPrimitiveMock::primitive::<&str>.stub(|each| {
-            each.call(matching!(PrimitiveEnum::Bar, _))
-                .answers(|_| PrimitiveEnum::Foo);
-        }))
-        .primitive(PrimitiveEnum::Bar, "")
-        {
-            PrimitiveEnum::Foo => {}
-            PrimitiveEnum::Bar => panic!(),
-        }
-    }
-
-    #[test]
-    #[should_panic(expected = "VeryPrimitive::primitive(?, ?): No matching call patterns.")]
-    fn should_format_non_debug_input_with_a_question_mark() {
-        Unimock::with_assoc(VeryPrimitiveMock::primitive::<&str>.stub(|each| {
-            each.call(matching!(PrimitiveEnum::Bar, _))
-                .answers(|_| PrimitiveEnum::Foo);
-        }))
-        .primitive(PrimitiveEnum::Foo, "");
-    }
-}
-
-#[test]
-fn should_debug_reference_to_debug_implementing_type() {
-    #[derive(Debug)]
-    pub enum DebugEnum {}
-
-    #[unimock(api=A)]
-    trait VeryPrimitiveRefZero {
-        type X;
-
-        fn primitive_ref(&self, a: DebugEnum) -> DebugEnum;
-    }
-
-    #[unimock(api=B)]
-    trait VeryPrimitiveRefOnce {
-        type X;
-
-        fn primitive_ref(&self, a: &DebugEnum) -> DebugEnum;
-    }
-
-    #[unimock(api=C)]
-    trait VeryPrimitiveRefTwice {
-        type X;
-
-        fn primitive_ref(&self, a: &&DebugEnum) -> DebugEnum;
-    }
-}
-
-#[test]
-fn should_be_able_to_borrow_a_returns_value() {
-    #[derive(Eq, PartialEq, Debug, Clone)]
-    pub struct Ret<T>(T);
-
-    #[unimock(api=BorrowsRetMock)]
-    trait BorrowsRet {
-        type X;
-
-        fn borrows_ret(&self) -> &Ret<Self::X>;
-    }
-
-    assert_eq!(
-        &Ret(42),
-        Unimock::with_assoc(
-            BorrowsRetMock::borrows_ret::<i32>
-                .each_call(matching!())
-                .returns(&Ret(42))
-        )
-        .borrows_ret()
-    );
-}
-
-#[test]
-fn various_borrowing() {
-    #[unimock(api=BorrowingMock)]
-    trait Borrowing {
-        type X;
-
-        fn borrow(&self, input: Self::X) -> &Self::X;
-        fn borrow_static(&self) -> &'static Self::X;
-    }
-    fn get_str<'s, B: Borrowing<X = String>>(t: &'s B, input: &str) -> &'s str {
-        t.borrow(input.to_string()).as_str()
-    }
-
-    let u = Unimock::with_assoc(
-        BorrowingMock::borrow::<String>
-            .next_call(matching!(_))
-            .returns("foo".to_string())
-            .once(),
-    );
-    assert_eq!("foo", get_str(&u, ""));
-    let u = Unimock::with_assoc(
-        BorrowingMock::borrow::<String>
-            .next_call(matching!(_))
-            .returns("foo".to_string())
-            .once(),
-    );
-    assert_eq!("foo", get_str(&u, ""));
-    let u = Unimock::with_assoc(
-        BorrowingMock::borrow::<String>
-            .next_call(matching!(_))
-            .answers(|input| format!("{input}{input}"))
-            .once(),
-    );
-    assert_eq!("yoyo", get_str(&u, "yo"));
-    let u: Unimock<AssocType<String>> = Unimock::with_assoc(
-        BorrowingMock::borrow_static::<String>
-            .next_call(matching!(_))
-            .answers_leaked_ref(|_| format!("yoyoyo"))
-            .once(),
-    );
-    assert_eq!("yoyoyo", u.borrow_static());
-}
-
-mod custom_api_module {
-    use unimock::*;
-
-    pub struct MyType;
-
-    #[unimock(api=FakeSingle)]
-    trait Single {
-        type X;
-
-        fn func(&self) -> &Self::X;
-    }
-
-    #[test]
-    #[should_panic(
-        expected = "Single::func: Expected Single::func(_) at tests/it/assoc_types.rs:427 to match exactly 1 call, but it actually matched no calls.\nMock for Single::func was never called. Dead mocks should be removed."
-    )]
-    fn test_without_module() {
-        Unimock::<AssocType<MyType>>::with_assoc(
-            FakeSingle::func::<MyType>
-                .next_call(matching!(_))
-                .returns(MyType)
-                .once(),
-        );
-    }
-}
-
-mod flattened_module {
-    mod assoc_types {
-        use unimock::*;
-
-        #[unimock(api=[Foo, Bar])]
-        trait WithUnpackedModule {
-            type X;
-
-            fn foo(&self, input: String) -> i32;
-            fn bar(&self);
-        }
-
-        #[test]
-        fn test_unpacked_module() {
-            let _ = Foo::<i32>.each_call(matching!(_)).returns(33);
-            let _ = Bar::<()>.each_call(matching!(_)).returns(());
-        }
-    }
-
-    mod generics {
-        use unimock::*;
-
-        #[unimock(api=[Foo, Bar])]
-        trait UnpackedGenerics<T> {
-            type X;
-
-            fn foo(&self, input: String) -> T;
-            fn bar(&self, input: &T);
-        }
-    }
-
-    mod exports {
-        mod inner {
-            use unimock::*;
-            #[unimock(api=[FooMock])]
-            pub trait Trait {
-                type X;
-
-                fn foo(&self);
-            }
-        }
-
-        #[test]
-        fn test_inner() {
-            use unimock::*;
-            let _ = inner::FooMock::<i32>.each_call(matching!()).returns(());
-        }
-    }
-}
-
-#[unimock(api=AsyncMock)]
-#[async_trait(?Send)]
-trait Async {
-    type X;
-
-    async fn func(&self, arg: Self::X) -> String;
-}
-
-#[tokio::test]
-async fn test_async_trait() {
-    async fn takes_async<A: Async>(a: &A, arg: A::X) -> String {
-        a.func(arg).await
-    }
-
-    assert_eq!(
-        "42",
-        takes_async(
-            &Unimock::with_assoc(AsyncMock::func::<i32>.stub(|each| {
-                each.call(matching!(_)).returns("42");
-            })),
-            21
-        )
-        .await
-    );
-}
-
-use std::borrow::Cow;
-
-#[unimock(api=CowBasedMock)]
-trait CowBased {
-    type X: ?Sized + ToOwned;
-
-    fn func(&self, arg: Cow<'static, Self::X>) -> Cow<'static, Self::X>;
-}
-
-#[test]
-fn test_cow() {
-    fn takes<C: CowBased>(t: &C, arg: Cow<'static, C::X>) -> Cow<'static, C::X> {
-        t.func(arg)
-    }
-
-    assert_eq!(
-        "output",
-        takes(
-            &Unimock::with_assoc(CowBasedMock::func::<str>.stub(|each| {
-                each.call(matching! {("input") | ("foo")}).returns("output");
-            })),
-            "input".into()
-        )
-    );
-}
-
-#[test]
-fn borrow_intricate_lifetimes() {
-    pub struct I<'s>(std::marker::PhantomData<&'s ()>);
-    pub struct O<'s>(&'s String);
-
-    #[unimock(api = IntricateMock)]
-    trait Intricate {
-        type X;
-
-        fn foo<'s, 't>(&'s self, inp: &'t I<'s>) -> &'s O<'t>;
-    }
-
-    fn takes_intricate(i: &impl Intricate) {
-        i.foo(&I(std::marker::PhantomData));
-    }
-
-    let u: Unimock<AssocType<()>> = Unimock::with_assoc(
-        IntricateMock::foo::<()>
-            .next_call(matching!(I(_)))
-            .returns(O(Box::leak(Box::new("leaked".to_string())))),
-    );
-
-    takes_intricate(&u);
-}
-
-#[test]
-fn clause_helpers() {
-    #[unimock(api=FooMock)]
-    trait Foo {
-        type X;
-
-        fn m1(&self) -> Self::X;
-    }
-
-    #[unimock(api=BarMock)]
-    trait Bar {
-        type X;
-
-        fn m2(&self) -> Self::X;
-    }
-    #[unimock(api=BazMock)]
-    trait Baz {
-        type X;
-
-        fn m3(&self) -> Self::X;
-    }
-
-    fn setup_foo_bar() -> impl Clause {
-        (
-            FooMock::m1::<i32>.some_call(matching!(_)).returns(1),
-            BarMock::m2::<i32>.each_call(matching!(_)).returns(2),
-        )
-    }
-
-    let deps: Unimock<AssocType<i32>> = Unimock::with_assoc((
-        setup_foo_bar(),
-        BazMock::m3::<i32>.each_call(matching!(_)).returns(3),
-    ));
-    assert_eq!(6, deps.m1() + deps.m2() + deps.m3());
-}
-
-mod responders_in_series {
-    use super::*;
-
-    #[unimock(api=SeriesMock)]
-    trait Series {
-        type X;
-
-        fn series(&self) -> Self::X;
-    }
-
-    fn clause() -> impl Clause {
-        SeriesMock::series::<i32>
-            .each_call(matching!())
-            .returns(1)
-            .once()
-            .then()
-            .returns(2)
-            .n_times(2)
-            .then()
-            .returns(3)
-            .at_least_times(1)
-    }
-
-    #[test]
-    fn responder_series_should_work() {
-        let a = Unimock::with_assoc(clause());
-
-        assert_eq!(1, a.series());
-        assert_eq!(2, a.series());
-        assert_eq!(2, a.series());
-        // it will continue to return 3:
-        assert_eq!(3, a.series());
-        assert_eq!(3, a.series());
-        assert_eq!(3, a.series());
-        assert_eq!(3, a.series());
-    }
-
-    #[test]
-    #[should_panic(
-        expected = "Series::series: Expected Series::series() at tests/it/assoc_types.rs:609 to match at least 4 calls, but it actually matched 2 calls."
-    )]
-    fn series_not_fully_generated_should_panic() {
-        let b = Unimock::with_assoc(clause());
-
-        assert_eq!(1, b.series());
-        assert_eq!(2, b.series());
-
-        // Exact repetition was defined to be 4 (the last responder is not exactly quantified), but it contained a `.then` call so minimum 1.
-    }
-}
-
-#[unimock(api=BorrowStaticMock)]
-trait BorrowStatic {
-    type X;
-
-    fn static_str(&self, arg: Self::X) -> &'static str;
-}
-
-#[test]
-fn borrow_static_should_work_with_returns_static() {
-    assert_eq!(
-        "foo",
-        Unimock::with_assoc(
-            BorrowStaticMock::static_str::<i32>
-                .next_call(matching!(_))
-                .returns("foo")
-        )
-        .static_str(33)
-    );
-}
-
-mod async_argument_borrowing {
-    use super::*;
-
-    #[unimock(api=BorrowParamMock)]
-    #[async_trait(?Send)]
-    trait BorrowParam {
-        type X;
-
-        async fn borrow_param<'a>(&self, arg: &'a Self::X) -> &'a Self::X;
-    }
-
-    #[tokio::test]
-    async fn test_argument_borrowing() {
-        let unimock = Unimock::with_assoc(
-            BorrowParamMock::borrow_param::<&str>
-                .each_call(matching!(_))
-                .returns(&"foobar"),
-        );
-
-        assert_eq!(&"foobar", unimock.borrow_param(&"input").await);
-    }
-
-    #[tokio::test]
-    async fn test_argument_borrowing_works() {
-        let unimock = Unimock::with_assoc(
-            BorrowParamMock::borrow_param::<&str>
-                .each_call(matching!(_))
-                .returns(&"foobar"),
-        );
-
-        unimock.borrow_param(&"input").await;
-    }
-}
-
-mod lifetime_constrained_output_type {
-    use super::*;
-
-    #[derive(Clone)]
-    pub struct Borrowing1<'a, T: ?Sized>(&'a T);
-
-    #[derive(Clone)]
-    pub struct Borrowing2<'a, 'b, T: ?Sized>(&'a T, &'b T);
-
-    #[unimock(api=BorrowSyncMock)]
-    trait BorrowSync {
-        type X: ?Sized;
-
-        fn borrow_sync_elided(&self) -> Borrowing1<'_, Self::X>;
-        fn borrow_sync_explicit(&self) -> Borrowing1<'_, Self::X>;
-        fn borrow_sync_explicit2<'a, 'b>(&'a self, arg: &'b str) -> Borrowing2<'a, 'b, Self::X>;
-    }
-
-    #[unimock(api=Unused)]
-    #[async_trait(?Send)]
-    trait BorrowAsync {
-        type X;
-
-        async fn borrow_async_elided(&self) -> Borrowing1<'_, Self::X>;
-        async fn borrow_async_explicit<'a>(&'a self) -> Borrowing1<'a, Self::X>;
-        async fn borrow_async_explicit2<'a, 'b>(
-            &'a self,
-            arg: &'b str,
-        ) -> Borrowing2<'a, 'b, Self::X>;
-    }
-
-    #[test]
-    fn test_borrow() {
-        let deps = Unimock::with_assoc(
-            BorrowSyncMock::borrow_sync_explicit2::<&str>
-                .some_call(matching!("foobar"))
-                .returns(Borrowing2(&"a", &"b")),
-        );
-
-        let result: Borrowing2<'_, '_, &str> = deps.borrow_sync_explicit2("foobar");
-        assert_eq!(result.0, &"a");
-        assert_eq!(result.1, &"b");
-    }
-
-    #[test]
-    fn test_borrow_sized() {
-        let deps = Unimock::with_assoc(
-            BorrowSyncMock::borrow_sync_explicit2::<str>
-                .some_call(matching!("foobar"))
-                .returns(Borrowing2("a", "b")),
-        );
-
-        let result: Borrowing2<'_, '_, str> = deps.borrow_sync_explicit2("foobar");
-        assert_eq!(result.0, "a");
-        assert_eq!(result.1, "b");
-    }
-}
-
-mod slice_matching {
-    use std::vec;
-
-    use super::*;
-
-    #[unimock(api = Mock)]
-    trait Trait {
-        type X;
-
-        type Y;
-
-        fn vec_of_i32(&self, a: Vec<Self::X>);
-        fn two_vec_of_i32(&self, a: Vec<Self::X>, b: Vec<Self::X>);
-        fn vec_of_string(&self, a: Vec<Self::Y>);
-    }
-
-    #[test]
-    fn vec_of_strings() {
-        Unimock::<AssocType<_, AssocType<String>>>::with_assoc(
-            Mock::vec_of_i32::<i32, String>
-                .next_call(matching!([1, 2]))
-                .returns(()),
-        )
-        .vec_of_i32(vec![1, 2]);
-        Unimock::<AssocType<_, AssocType<String>>>::with_assoc(
-            Mock::two_vec_of_i32::<i32, String>
-                .next_call(matching!([1, 2], [3, 4]))
-                .returns(()),
-        )
-        .two_vec_of_i32(vec![1, 2], vec![3, 4]);
-        Unimock::<AssocType<i32, AssocType<_>>>::with_assoc(
-            Mock::vec_of_string::<i32, String>
-                .next_call(matching!(([a, b]) if a == "1" && b == "2"))
-                .returns(()),
-        )
-        .vec_of_string(vec!["1".to_string(), "2".to_string()]);
-    }
-}
-
-#[test]
-fn eval_name_clash() {
-    #[unimock(api = Mock, unmock_with=[unmock])]
-    trait Trait {
-        type X;
-
-        fn tralala(&self, eval: Self::X);
-    }
-
-    fn unmock<X>(_: &impl std::any::Any, _: X) {}
-}
-
-#[test]
-fn fn_cfg_attrs() {
-    #[unimock(api = TraitMock)]
-    trait Trait {
-        type X;
-
-        fn a(&self) -> Self::X;
-
-        #[cfg(feature = "always-disabled")]
-        fn b(&self) -> NonExistentType;
-    }
-
-    let u = Unimock::with_assoc(TraitMock::a::<i32>.next_call(matching!()).returns(0));
-    assert_eq!(0, u.a());
-}
-
-mod output {
-    use super::*;
-
-    #[unimock(api=GenericOutputMock)]
-    trait GenericOutput<T> {
-        type X;
-        fn generic_output(&self) -> T;
-    }
-
-    #[test]
-    fn test_generic_return() {
-        let deps: Unimock<AssocType<String>> = Unimock::with_assoc(
-            GenericOutputMock::generic_output::<String>
-                .with_types::<String>()
-                .each_call(matching!())
-                .returns("success".to_string()),
-        );
-
-        let output = <Unimock<_> as GenericOutput<String>>::generic_output(&deps);
-        assert_eq!("success", output);
-
-        // let output = <Unimock as GenericOutput<i32>>::generic_output(&deps);
-        // assert_eq!(42, output);
-    }
-}
-
-mod param {
-    use super::*;
-    use std::fmt::Debug;
-
-    #[unimock(api=GenericParamMock)]
-    trait GenericParam<T> {
-        type X;
-        fn generic_param(&self, param: T) -> &'static str;
-    }
-
-    #[test]
-    fn test_generic_param() {
-        let deps: Unimock<AssocType<i32>> = Unimock::with_assoc((
-            GenericParamMock::generic_param::<i32>
-                .with_types::<&'static str>()
-                .each_call(matching!("foobar"))
-                .returns("a string"),
-            GenericParamMock::generic_param::<i32>
-                .with_types::<i32>()
-                .each_call(matching!(42))
-                .returns("a number"),
-        ));
-
-        assert_eq!("a string", deps.generic_param("foobar"));
-        assert_eq!("a number", deps.generic_param(42_i32));
-    }
-
-    #[test]
-    #[should_panic(
-        // Since the generic parameter has no Debug bound, we cannot see the parameter:
-        expected = "GenericParam::generic_param(?): No matching call patterns."
-    )]
-    fn test_generic_param_panic_no_debug() {
-        let deps: Unimock<AssocType<i32>> = Unimock::with_assoc(
-            GenericParamMock::generic_param::<i32>
-                .with_types::<i32>()
-                .each_call(matching!(1337))
-                .returns("a number"),
-        );
-
-        deps.generic_param(42_i32);
-    }
-
-    #[unimock(api=GenericParamDebugMock)]
-    trait GenericParamDebug<T: Debug> {
-        type X;
-        fn generic_param_debug(&self, param: T) -> &'static str;
-    }
-
-    #[test]
-    #[should_panic(
-        // When it has a debug bound, we should see it:
-        expected = "GenericParamDebug::generic_param_debug(42): No matching call patterns."
-    )]
-    fn test_generic_param_panic_debug() {
-        let deps: Unimock<AssocType<i32>> = Unimock::with_assoc(
-            GenericParamDebugMock::generic_param_debug::<i32>
-                .with_types::<i32>()
-                .each_call(matching!(1337))
-                .returns("a number"),
-        );
-
-        deps.generic_param_debug(42_i32);
-    }
-}
-
-mod combined {
-    use super::*;
-    use std::fmt::Debug;
-
-    #[unimock(api=A)]
-    trait GenericBounds<I: Debug, O: Clone> {
-        type X;
-        fn generic_bounds(&self, param: I) -> O;
-    }
-
-    #[unimock(api=B)]
-    trait GenericWhereBounds<I, O>
-    where
-        I: Debug,
-        O: Clone,
-    {
-        type X;
-        fn generic_where_bounds(&self, param: I) -> O;
-    }
-}
-
-mod async_generic {
-    use super::*;
-    use std::fmt::Debug;
-
-    #[unimock(api=A)]
-    #[async_trait::async_trait(?Send)]
-    trait AsyncTraitGenericBounds<I: Debug, O: Clone> {
-        type X;
-        async fn generic_bounds(&self, param: I) -> O;
-    }
-}
-
-mod generic_without_module {
-    use super::*;
-    use std::fmt::Debug;
-
-    #[unimock(api=[Func])]
-    trait WithModule<T: Debug> {
-        type X;
-        fn func(&self) -> T;
-    }
-
-    #[test]
-    fn mock() {
-        Func::<i32>
-            .with_types::<String>()
-            .each_call(matching!())
-            .returns("".to_string());
-    }
-}
-
-mod generic_with_unmock {
-    use super::*;
-
-    // unmock is not implemented
-
-    // #[unimock(unmock_with=[gen_default(self)])]
-    // trait UnmockMe<T: Default> {
-    //     type X;
-    //     fn unmock_me(&self) -> T;
-    // }
-
-    // #[unimock(unmock_with=[gen_default(self)])]
-    // trait UnmockMeWhere<T>
-    // where
-    //     T: Default,
-    // {
-    //     type X;
-    //     fn unmock_me_where(&self) -> T;
-    // }
-
-    fn gen_default<D, T: Default>(_: &D) -> T {
-        T::default()
-    }
-}
-
-use unimock::*;
-
-mod clone {
-
-    #[derive(Eq, PartialEq, Debug)]
-    pub struct Nope;
-
-    #[derive(Clone, Eq, PartialEq, Debug)]
-    pub struct Sure;
-}
-
-#[unimock(api=InOptionMock)]
-trait InOption {
-    type X;
-    fn str(&self, a: &str) -> Option<&str>;
-    fn not_clone(&self) -> Option<&clone::Nope>;
-}
-
-#[test]
-fn in_option() {
-    let u: Unimock<AssocType<()>> = Unimock::with_assoc((
-        InOptionMock::str::<()>
-            .next_call(matching!(_))
-            .returns(Some("1".to_string())),
-        InOptionMock::str::<()>
-            .next_call(matching!(_))
-            .returns(Some("2")),
-        InOptionMock::str::<()>
-            .next_call(matching!(_))
-            .returns(None::<&str>),
-    ));
-    assert_eq!(Some("1"), u.str(""));
-    assert_eq!(Some("2"), u.str(""));
-    assert_eq!(None, u.str(""));
-}
-
-// This test demonstrates that a `T: Clone` bound is not necessary
-// on each_call for `Option<&T>`, since the outer option
-// can be generically reconstructed from the inner borrowed one
-#[test]
-fn in_option_not_clone_can_clone_anyway() {
-    let u: Unimock<AssocType<()>> = Unimock::with_assoc(
-        InOptionMock::not_clone::<()>
-            .each_call(matching!())
-            .returns(Some(clone::Nope)),
-    );
-    assert_eq!(Some(&clone::Nope), <Unimock<_> as InOption>::not_clone(&u));
-    assert_eq!(Some(&clone::Nope), <Unimock<_> as InOption>::not_clone(&u));
-}
-
-#[unimock(api=InResultMock)]
-trait InResult {
-    type X;
-    fn bytes(&self) -> Result<&[u8], clone::Nope>;
-    fn u32_clone(&self) -> Result<&u32, clone::Sure>;
-    fn ok_no_clone(&self, ok: bool) -> Result<&clone::Nope, clone::Sure>;
-    fn err_no_clone(&self) -> Result<&clone::Nope, clone::Nope>;
-}
-
-#[test]
-fn in_result() {
-    let u: Unimock<AssocType<()>> = Unimock::with_assoc((
-        InResultMock::bytes::<()>
-            .next_call(matching!())
-            .returns(Ok(vec![42])),
-        InResultMock::bytes::<()>
-            .next_call(matching!())
-            .returns(Err::<&[u8], _>(clone::Nope)),
-        InResultMock::u32_clone::<()>
-            .each_call(matching!())
-            .returns(Ok(42))
-            .at_least_times(2),
-    ));
-
-    assert_eq!(Ok(vec![42].as_slice()), <Unimock<_> as InResult>::bytes(&u));
-    assert_eq!(Err(clone::Nope), <Unimock<_> as InResult>::bytes(&u));
-    assert_eq!(Ok(&42), <Unimock<_> as InResult>::u32_clone(&u));
-    assert_eq!(Ok(&42), <Unimock<_> as InResult>::u32_clone(&u));
-}
-
-#[test]
-fn in_result_clone_acrobatics() {
-    let u: Unimock<AssocType<()>> = Unimock::with_assoc((
-        InResultMock::ok_no_clone::<()>
-            .each_call(matching!(true))
-            .returns(Ok(clone::Nope)),
-        InResultMock::ok_no_clone::<()>
-            .each_call(matching!(false))
-            .returns(Err::<&clone::Nope, _>(clone::Sure)),
-        InResultMock::err_no_clone::<()>
-            .some_call(matching!()) // note: .each_call is impossible
-            .returns(Err::<&clone::Nope, _>(clone::Nope)),
-    ));
-
-    for _ in 0..3 {
-        assert_eq!(Ok(&clone::Nope), u.ok_no_clone(true));
-        assert_eq!(Err(clone::Sure), u.ok_no_clone(false));
-    }
-
-    assert_eq!(Err(clone::Nope), u.err_no_clone());
-}
-
-#[test]
-#[should_panic(
-    expected = "InResult::ok_no_clone: Expected InResult::ok_no_clone(_) at tests/it/assoc_types.rs:1105 to match exactly 1 call, but it actually matched 2 calls."
-)]
-fn in_result_may_multi_respond_on_ok_no_clone() {
-    let u: Unimock<AssocType<()>> = Unimock::with_assoc(
-        InResultMock::ok_no_clone::<()>
-            .some_call(matching!(_))
-            .returns(Ok(clone::Nope)),
-    );
-
-    assert_eq!(Ok(&clone::Nope), u.ok_no_clone(true));
-    assert_eq!(Ok(&clone::Nope), u.ok_no_clone(true));
-}
-
-#[unimock(api = InVecMock)]
-trait InVec {
-    type X;
-    fn vector(&self) -> Vec<&i32>;
-}
-
-#[test]
-fn in_vec() {
-    let u: Unimock<AssocType<()>> = Unimock::with_assoc(
-        InVecMock::vector::<()>
-            .each_call(matching!())
-            .returns(vec![1, 2, 3]),
-    );
-
-    assert_eq!(vec![&1, &2, &3], u.vector());
-}
-
-#[unimock(api = MixedTupleMock)]
-trait MixedTuple {
-    type X;
-    fn tuple1(&self) -> (&i32,);
-    fn tuple2a(&self) -> (&i32, i32);
-    fn tuple2b(&self) -> (i32, &i32);
-    fn tuple4(&self) -> (&clone::Nope, clone::Nope, &clone::Sure, clone::Sure);
-}
-
-#[test]
-fn mixed_tuple1() {
-    let u: Unimock<AssocType<()>> = Unimock::with_assoc((
-        MixedTupleMock::tuple2a::<()>
-            .next_call(matching!())
-            .returns((1, 2)),
-        MixedTupleMock::tuple2b::<()>
-            .next_call(matching!())
-            .returns((1, 2)),
-    ));
-
-    assert_eq!((&1, 2), u.tuple2a());
-    assert_eq!((1, &2), u.tuple2b());
-}
-
-#[test]
-fn mixed_tuple_clone_combinatorics_once() {
-    let u: Unimock<AssocType<()>> = Unimock::with_assoc(
-        MixedTupleMock::tuple4::<()>
-            .next_call(matching!())
-            .returns((clone::Nope, clone::Nope, clone::Sure, clone::Sure)),
-    );
-
-    assert_eq!(
-        (&clone::Nope, clone::Nope, &clone::Sure, clone::Sure),
-        u.tuple4()
-    );
-}
-
-#[test]
-fn mixed_tuple_clone_combinatorics_many() {
-    let u: Unimock<AssocType<()>> = Unimock::with_assoc(
-        MixedTupleMock::tuple4::<()>
-            .each_call(matching!())
-            .answers(|_| (clone::Nope, clone::Nope, clone::Sure, clone::Sure)),
-    );
-
-    for _ in 0..3 {
-        assert_eq!(
-            (&clone::Nope, clone::Nope, &clone::Sure, clone::Sure),
-            u.tuple4()
-        );
-    }
-}
+// #[test]
+// fn noarg_works() {
+//     #[unimock(api=NoArgMock)]
+//     trait NoArg {
+//         type X;
+
+//         fn no_arg(&self) -> Self::X;
+//     }
+
+//     assert_eq!(
+//         1_000_000,
+//         Unimock::with_assoc(
+//             NoArgMock::no_arg::<i32>
+//                 .next_call(matching!())
+//                 .returns(1_000_000)
+//         )
+//         .no_arg()
+//     );
+// }
+
+// #[test]
+// fn owned_output_works() {
+//     #[unimock(api=OwnedMock)]
+//     trait Owned {
+//         type X;
+
+//         fn foo(&self, a: String, b: Self::X) -> Self::X;
+//     }
+
+//     fn takes_owned<O: Owned<X = String>>(
+//         o: &O,
+//         a: impl Into<String>,
+//         b: impl Into<O::X>,
+//     ) -> String {
+//         o.foo(a.into(), b.into())
+//     }
+
+//     assert_eq!(
+//         "ab",
+//         takes_owned(
+//             &Unimock::with_assoc(
+//                 OwnedMock::foo::<String>
+//                     .next_call(matching!(_, _))
+//                     .answers(|(a, b)| format!("{a}{b}"))
+//                     .once()
+//             ),
+//             "a",
+//             "b",
+//         )
+//     );
+//     assert_eq!(
+//         "lol",
+//         takes_owned(
+//             &Unimock::with_assoc(OwnedMock::foo::<String>.stub(|each| {
+//                 each.call(matching!(_, _)).returns("lol");
+//             })),
+//             "a",
+//             "b",
+//         )
+//     );
+//     assert_eq!(
+//         "",
+//         takes_owned(
+//             &Unimock::with_assoc(OwnedMock::foo::<String>.stub(|each| {
+//                 each.call(matching!("a", "b")).returns_default();
+//             })),
+//             "a",
+//             "b",
+//         )
+//     );
+// }
+
+// mod exotic_self_types {
+//     use super::*;
+//     use std::rc::Rc;
+
+//     #[unimock(api=OwnedSelfMock)]
+//     trait OwnedSelf {
+//         type X;
+
+//         fn foo(self);
+//     }
+
+//     #[unimock(api=MutSelfMock)]
+//     trait MutSelf {
+//         type X;
+
+//         fn mut_self(&mut self);
+//     }
+
+//     #[unimock(api=RcSelfMock)]
+//     trait RcSelf {
+//         type X;
+
+//         fn rc_self(self: Rc<Self>);
+//     }
+
+//     #[test]
+//     fn mut_self() {
+//         let mut u: Unimock<AssocType<i32>> = Unimock::with_assoc(
+//             MutSelfMock::mut_self::<i32>
+//                 .each_call(matching!())
+//                 .returns(()),
+//         );
+
+//         u.mut_self();
+//     }
+
+//     #[test]
+//     fn rc_self() {
+//         let deps: Rc<Unimock<AssocType<i32>>> = Rc::new(Unimock::with_assoc(
+//             RcSelfMock::rc_self::<i32>
+//                 .each_call(matching!())
+//                 .returns(()),
+//         ));
+
+//         deps.rc_self();
+//     }
+// }
+
+// mod exotic_methods {
+//     use super::*;
+
+//     #[unimock(api=ProvidedMock)]
+//     trait Provided {
+//         type X: Default;
+
+//         fn not_provided(&self);
+//         fn provided(&self) -> Self::X {
+//             Self::X::default()
+//         }
+//     }
+
+//     #[test]
+//     fn test_provided() {
+//         let deps = Unimock::with_assoc(
+//             ProvidedMock::provided::<i32>
+//                 .each_call(matching!())
+//                 .returns(42),
+//         );
+//         assert_eq!(42, deps.provided());
+//     }
+
+//     #[unimock]
+//     trait SkipStaticProvided {
+//         type X;
+
+//         fn skip1() {}
+//         fn skip2(arg: i32) -> i32 {
+//             arg
+//         }
+//     }
+// }
+
+// mod referenced {
+//     use super::*;
+
+//     #[unimock(api=ReferencedMock)]
+//     trait Referenced {
+//         type X;
+
+//         fn foo(&self, a: &str) -> &str;
+//         fn bar(&self, a: &str, b: &str) -> &str;
+//     }
+
+//     fn takes_referenced<'s, 'x, R: Referenced<X = &'x str>>(r: &'s R, a: R::X) -> &'s str {
+//         r.foo(a)
+//     }
+
+//     #[test]
+//     fn referenced_with_static_return_value_works() {
+//         let u = Unimock::with_assoc(ReferencedMock::foo::<&str>.stub(|each| {
+//             each.call(matching!("a")).returns("answer".to_string());
+//         }));
+//         assert_eq!("answer", takes_referenced(&u, "a",));
+//     }
+
+//     #[test]
+//     fn referenced_with_default_return_value_works() {
+//         let u = Unimock::with_assoc(ReferencedMock::foo::<&str>.stub(|each| {
+//             each.call(matching!("Æ")).panics("Should not be called");
+//             each.call(matching!("a")).returns(String::new());
+//         }));
+//         assert_eq!("", takes_referenced(&u, "a",));
+//     }
+
+//     #[test]
+//     fn referenced_with_static_ref_works() {
+//         let u = Unimock::with_assoc(ReferencedMock::foo::<&str>.stub(|each| {
+//             each.call(matching!("a")).returns("foobar");
+//         }));
+//         assert_eq!("foobar", takes_referenced(&u, "a",));
+//     }
+// }
+
+// mod no_clone_return {
+//     use unimock::*;
+
+//     #[derive(Debug, PartialEq)]
+//     pub struct NoClone(i32);
+
+//     #[unimock(api=FooMock)]
+//     trait Foo {
+//         type X;
+
+//         fn foo(&self) -> Self::X;
+//     }
+
+//     #[test]
+//     fn test_no_clone_return() {
+//         let u = Unimock::with_assoc(
+//             FooMock::foo::<NoClone>
+//                 .some_call(matching!())
+//                 .returns(NoClone(55)),
+//         );
+//         assert_eq!(NoClone(55), u.foo());
+//     }
+// }
+
+// mod each_call_implicitly_clones {
+//     use unimock::*;
+
+//     #[unimock(api=FooMock)]
+//     trait Foo {
+//         type X;
+
+//         fn foo(&self) -> Self::X;
+//     }
+
+//     #[test]
+//     fn each_call_implicit_clone() {
+//         let u = Unimock::with_assoc(FooMock::foo::<i32>.each_call(matching!()).returns(55));
+//         assert_eq!(55, u.foo());
+//         assert_eq!(55, u.foo());
+//     }
+// }
+
+// #[unimock(api=SingleArgMock)]
+// trait SingleArg {
+//     type X;
+
+//     fn method1<'i>(&'i self, a: &'i str) -> &'i Self::X;
+// }
+
+// #[unimock(api=MultiArgMock)]
+// trait MultiArg {
+//     type X;
+
+//     fn method2(&self, a: &str, b: &str) -> &Self::X;
+// }
+
+// #[test]
+// fn test_multiple() {
+//     fn takes_single_multi(
+//         t: &(impl SingleArg<X = &'static str> + MultiArg<X = &'static str>),
+//     ) -> &str {
+//         let tmp = t.method1("b");
+//         t.method2(tmp, tmp)
+//     }
+
+//     let u = Unimock::with_assoc((
+//         SingleArgMock::method1::<&'static str>.stub(|each| {
+//             each.call(matching!("b")).returns("B").once();
+//         }),
+//         MultiArgMock::method2::<&'static str>.stub(|each| {
+//             each.call(matching!("a", _)).panics("should not call this");
+//             each.call(matching!("B", "B")).returns("success").once();
+//         }),
+//     ));
+//     assert_eq!("success", takes_single_multi(&u));
+// }
+
+// mod no_debug {
+//     use super::*;
+
+//     pub enum PrimitiveEnum {
+//         Foo,
+//         Bar,
+//     }
+
+//     #[unimock(api=VeryPrimitiveMock)]
+//     trait VeryPrimitive {
+//         type X;
+
+//         fn primitive(&self, a: PrimitiveEnum, b: Self::X) -> PrimitiveEnum;
+//     }
+
+//     #[test]
+//     fn can_match_a_non_debug_argument() {
+//         match Unimock::with_assoc(VeryPrimitiveMock::primitive::<&str>.stub(|each| {
+//             each.call(matching!(PrimitiveEnum::Bar, _))
+//                 .answers(|_| PrimitiveEnum::Foo);
+//         }))
+//         .primitive(PrimitiveEnum::Bar, "")
+//         {
+//             PrimitiveEnum::Foo => {}
+//             PrimitiveEnum::Bar => panic!(),
+//         }
+//     }
+
+//     #[test]
+//     #[should_panic(expected = "VeryPrimitive::primitive(?, ?): No matching call patterns.")]
+//     fn should_format_non_debug_input_with_a_question_mark() {
+//         Unimock::with_assoc(VeryPrimitiveMock::primitive::<&str>.stub(|each| {
+//             each.call(matching!(PrimitiveEnum::Bar, _))
+//                 .answers(|_| PrimitiveEnum::Foo);
+//         }))
+//         .primitive(PrimitiveEnum::Foo, "");
+//     }
+// }
+
+// #[test]
+// fn should_debug_reference_to_debug_implementing_type() {
+//     #[derive(Debug)]
+//     pub enum DebugEnum {}
+
+//     #[unimock(api=A)]
+//     trait VeryPrimitiveRefZero {
+//         type X;
+
+//         fn primitive_ref(&self, a: DebugEnum) -> DebugEnum;
+//     }
+
+//     #[unimock(api=B)]
+//     trait VeryPrimitiveRefOnce {
+//         type X;
+
+//         fn primitive_ref(&self, a: &DebugEnum) -> DebugEnum;
+//     }
+
+//     #[unimock(api=C)]
+//     trait VeryPrimitiveRefTwice {
+//         type X;
+
+//         fn primitive_ref(&self, a: &&DebugEnum) -> DebugEnum;
+//     }
+// }
+
+// #[test]
+// fn should_be_able_to_borrow_a_returns_value() {
+//     #[derive(Eq, PartialEq, Debug, Clone)]
+//     pub struct Ret<T>(T);
+
+//     #[unimock(api=BorrowsRetMock)]
+//     trait BorrowsRet {
+//         type X;
+
+//         fn borrows_ret(&self) -> &Ret<Self::X>;
+//     }
+
+//     assert_eq!(
+//         &Ret(42),
+//         Unimock::with_assoc(
+//             BorrowsRetMock::borrows_ret::<i32>
+//                 .each_call(matching!())
+//                 .returns(&Ret(42))
+//         )
+//         .borrows_ret()
+//     );
+// }
+
+// #[test]
+// fn various_borrowing() {
+//     #[unimock(api=BorrowingMock)]
+//     trait Borrowing {
+//         type X;
+
+//         fn borrow(&self, input: Self::X) -> &Self::X;
+//         fn borrow_static(&self) -> &'static Self::X;
+//     }
+//     fn get_str<'s, B: Borrowing<X = String>>(t: &'s B, input: &str) -> &'s str {
+//         t.borrow(input.to_string()).as_str()
+//     }
+
+//     let u = Unimock::with_assoc(
+//         BorrowingMock::borrow::<String>
+//             .next_call(matching!(_))
+//             .returns("foo".to_string())
+//             .once(),
+//     );
+//     assert_eq!("foo", get_str(&u, ""));
+//     let u = Unimock::with_assoc(
+//         BorrowingMock::borrow::<String>
+//             .next_call(matching!(_))
+//             .returns("foo".to_string())
+//             .once(),
+//     );
+//     assert_eq!("foo", get_str(&u, ""));
+//     let u = Unimock::with_assoc(
+//         BorrowingMock::borrow::<String>
+//             .next_call(matching!(_))
+//             .answers(|input| format!("{input}{input}"))
+//             .once(),
+//     );
+//     assert_eq!("yoyo", get_str(&u, "yo"));
+//     let u: Unimock<AssocType<String>> = Unimock::with_assoc(
+//         BorrowingMock::borrow_static::<String>
+//             .next_call(matching!(_))
+//             .answers_leaked_ref(|_| format!("yoyoyo"))
+//             .once(),
+//     );
+//     assert_eq!("yoyoyo", u.borrow_static());
+// }
+
+// mod custom_api_module {
+//     use unimock::*;
+
+//     pub struct MyType;
+
+//     #[unimock(api=FakeSingle)]
+//     trait Single {
+//         type X;
+
+//         fn func(&self) -> &Self::X;
+//     }
+
+//     #[test]
+//     #[should_panic(
+//         expected = "Single::func: Expected Single::func(_) at tests/it/assoc_types.rs:427 to match exactly 1 call, but it actually matched no calls.\nMock for Single::func was never called. Dead mocks should be removed."
+//     )]
+//     fn test_without_module() {
+//         Unimock::<AssocType<MyType>>::with_assoc(
+//             FakeSingle::func::<MyType>
+//                 .next_call(matching!(_))
+//                 .returns(MyType)
+//                 .once(),
+//         );
+//     }
+// }
+
+// mod flattened_module {
+//     mod assoc_types {
+//         use unimock::*;
+
+//         #[unimock(api=[Foo, Bar])]
+//         trait WithUnpackedModule {
+//             type X;
+
+//             fn foo(&self, input: String) -> i32;
+//             fn bar(&self);
+//         }
+
+//         #[test]
+//         fn test_unpacked_module() {
+//             let _ = Foo::<i32>.each_call(matching!(_)).returns(33);
+//             let _ = Bar::<()>.each_call(matching!(_)).returns(());
+//         }
+//     }
+
+//     mod generics {
+//         use unimock::*;
+
+//         #[unimock(api=[Foo, Bar])]
+//         trait UnpackedGenerics<T> {
+//             type X;
+
+//             fn foo(&self, input: String) -> T;
+//             fn bar(&self, input: &T);
+//         }
+//     }
+
+//     mod exports {
+//         mod inner {
+//             use unimock::*;
+//             #[unimock(api=[FooMock])]
+//             pub trait Trait {
+//                 type X;
+
+//                 fn foo(&self);
+//             }
+//         }
+
+//         #[test]
+//         fn test_inner() {
+//             use unimock::*;
+//             let _ = inner::FooMock::<i32>.each_call(matching!()).returns(());
+//         }
+//     }
+// }
+
+// #[unimock(api=AsyncMock)]
+// #[async_trait(?Send)]
+// trait Async {
+//     type X;
+
+//     async fn func(&self, arg: Self::X) -> String;
+// }
+
+// #[tokio::test]
+// async fn test_async_trait() {
+//     async fn takes_async<A: Async>(a: &A, arg: A::X) -> String {
+//         a.func(arg).await
+//     }
+
+//     assert_eq!(
+//         "42",
+//         takes_async(
+//             &Unimock::with_assoc(AsyncMock::func::<i32>.stub(|each| {
+//                 each.call(matching!(_)).returns("42");
+//             })),
+//             21
+//         )
+//         .await
+//     );
+// }
+
+// use std::borrow::Cow;
+
+// #[unimock(api=CowBasedMock)]
+// trait CowBased {
+//     type X: ?Sized + ToOwned;
+
+//     fn func(&self, arg: Cow<'static, Self::X>) -> Cow<'static, Self::X>;
+// }
+
+// #[test]
+// fn test_cow() {
+//     fn takes<C: CowBased>(t: &C, arg: Cow<'static, C::X>) -> Cow<'static, C::X> {
+//         t.func(arg)
+//     }
+
+//     assert_eq!(
+//         "output",
+//         takes(
+//             &Unimock::with_assoc(CowBasedMock::func::<str>.stub(|each| {
+//                 each.call(matching! {("input") | ("foo")}).returns("output");
+//             })),
+//             "input".into()
+//         )
+//     );
+// }
+
+// #[test]
+// fn borrow_intricate_lifetimes() {
+//     pub struct I<'s>(std::marker::PhantomData<&'s ()>);
+//     pub struct O<'s>(&'s String);
+
+//     #[unimock(api = IntricateMock)]
+//     trait Intricate {
+//         type X;
+
+//         fn foo<'s, 't>(&'s self, inp: &'t I<'s>) -> &'s O<'t>;
+//     }
+
+//     fn takes_intricate(i: &impl Intricate) {
+//         i.foo(&I(std::marker::PhantomData));
+//     }
+
+//     let u: Unimock<AssocType<()>> = Unimock::with_assoc(
+//         IntricateMock::foo::<()>
+//             .next_call(matching!(I(_)))
+//             .returns(O(Box::leak(Box::new("leaked".to_string())))),
+//     );
+
+//     takes_intricate(&u);
+// }
+
+// #[test]
+// fn clause_helpers() {
+//     #[unimock(api=FooMock)]
+//     trait Foo {
+//         type X;
+
+//         fn m1(&self) -> Self::X;
+//     }
+
+//     #[unimock(api=BarMock)]
+//     trait Bar {
+//         type X;
+
+//         fn m2(&self) -> Self::X;
+//     }
+//     #[unimock(api=BazMock)]
+//     trait Baz {
+//         type X;
+
+//         fn m3(&self) -> Self::X;
+//     }
+
+//     fn setup_foo_bar() -> impl Clause {
+//         (
+//             FooMock::m1::<i32>.some_call(matching!(_)).returns(1),
+//             BarMock::m2::<i32>.each_call(matching!(_)).returns(2),
+//         )
+//     }
+
+//     let deps: Unimock<AssocType<i32>> = Unimock::with_assoc((
+//         setup_foo_bar(),
+//         BazMock::m3::<i32>.each_call(matching!(_)).returns(3),
+//     ));
+//     assert_eq!(6, deps.m1() + deps.m2() + deps.m3());
+// }
+
+// mod responders_in_series {
+//     use super::*;
+
+//     #[unimock(api=SeriesMock)]
+//     trait Series {
+//         type X;
+
+//         fn series(&self) -> Self::X;
+//     }
+
+//     fn clause() -> impl Clause {
+//         SeriesMock::series::<i32>
+//             .each_call(matching!())
+//             .returns(1)
+//             .once()
+//             .then()
+//             .returns(2)
+//             .n_times(2)
+//             .then()
+//             .returns(3)
+//             .at_least_times(1)
+//     }
+
+//     #[test]
+//     fn responder_series_should_work() {
+//         let a = Unimock::with_assoc(clause());
+
+//         assert_eq!(1, a.series());
+//         assert_eq!(2, a.series());
+//         assert_eq!(2, a.series());
+//         // it will continue to return 3:
+//         assert_eq!(3, a.series());
+//         assert_eq!(3, a.series());
+//         assert_eq!(3, a.series());
+//         assert_eq!(3, a.series());
+//     }
+
+//     #[test]
+//     #[should_panic(
+//         expected = "Series::series: Expected Series::series() at tests/it/assoc_types.rs:609 to match at least 4 calls, but it actually matched 2 calls."
+//     )]
+//     fn series_not_fully_generated_should_panic() {
+//         let b = Unimock::with_assoc(clause());
+
+//         assert_eq!(1, b.series());
+//         assert_eq!(2, b.series());
+
+//         // Exact repetition was defined to be 4 (the last responder is not exactly quantified), but it contained a `.then` call so minimum 1.
+//     }
+// }
+
+// #[unimock(api=BorrowStaticMock)]
+// trait BorrowStatic {
+//     type X;
+
+//     fn static_str(&self, arg: Self::X) -> &'static str;
+// }
+
+// #[test]
+// fn borrow_static_should_work_with_returns_static() {
+//     assert_eq!(
+//         "foo",
+//         Unimock::with_assoc(
+//             BorrowStaticMock::static_str::<i32>
+//                 .next_call(matching!(_))
+//                 .returns("foo")
+//         )
+//         .static_str(33)
+//     );
+// }
+
+// mod async_argument_borrowing {
+//     use super::*;
+
+//     #[unimock(api=BorrowParamMock)]
+//     #[async_trait(?Send)]
+//     trait BorrowParam {
+//         type X;
+
+//         async fn borrow_param<'a>(&self, arg: &'a Self::X) -> &'a Self::X;
+//     }
+
+//     #[tokio::test]
+//     async fn test_argument_borrowing() {
+//         let unimock = Unimock::with_assoc(
+//             BorrowParamMock::borrow_param::<&str>
+//                 .each_call(matching!(_))
+//                 .returns(&"foobar"),
+//         );
+
+//         assert_eq!(&"foobar", unimock.borrow_param(&"input").await);
+//     }
+
+//     #[tokio::test]
+//     async fn test_argument_borrowing_works() {
+//         let unimock = Unimock::with_assoc(
+//             BorrowParamMock::borrow_param::<&str>
+//                 .each_call(matching!(_))
+//                 .returns(&"foobar"),
+//         );
+
+//         unimock.borrow_param(&"input").await;
+//     }
+// }
+
+// mod lifetime_constrained_output_type {
+//     use super::*;
+
+//     #[derive(Clone)]
+//     pub struct Borrowing1<'a, T: ?Sized>(&'a T);
+
+//     #[derive(Clone)]
+//     pub struct Borrowing2<'a, 'b, T: ?Sized>(&'a T, &'b T);
+
+//     #[unimock(api=BorrowSyncMock)]
+//     trait BorrowSync {
+//         type X: ?Sized;
+
+//         fn borrow_sync_elided(&self) -> Borrowing1<'_, Self::X>;
+//         fn borrow_sync_explicit(&self) -> Borrowing1<'_, Self::X>;
+//         fn borrow_sync_explicit2<'a, 'b>(&'a self, arg: &'b str) -> Borrowing2<'a, 'b, Self::X>;
+//     }
+
+//     #[unimock(api=Unused)]
+//     #[async_trait(?Send)]
+//     trait BorrowAsync {
+//         type X;
+
+//         async fn borrow_async_elided(&self) -> Borrowing1<'_, Self::X>;
+//         async fn borrow_async_explicit<'a>(&'a self) -> Borrowing1<'a, Self::X>;
+//         async fn borrow_async_explicit2<'a, 'b>(
+//             &'a self,
+//             arg: &'b str,
+//         ) -> Borrowing2<'a, 'b, Self::X>;
+//     }
+
+//     #[test]
+//     fn test_borrow() {
+//         let deps = Unimock::with_assoc(
+//             BorrowSyncMock::borrow_sync_explicit2::<&str>
+//                 .some_call(matching!("foobar"))
+//                 .returns(Borrowing2(&"a", &"b")),
+//         );
+
+//         let result: Borrowing2<'_, '_, &str> = deps.borrow_sync_explicit2("foobar");
+//         assert_eq!(result.0, &"a");
+//         assert_eq!(result.1, &"b");
+//     }
+
+//     #[test]
+//     fn test_borrow_sized() {
+//         let deps = Unimock::with_assoc(
+//             BorrowSyncMock::borrow_sync_explicit2::<str>
+//                 .some_call(matching!("foobar"))
+//                 .returns(Borrowing2("a", "b")),
+//         );
+
+//         let result: Borrowing2<'_, '_, str> = deps.borrow_sync_explicit2("foobar");
+//         assert_eq!(result.0, "a");
+//         assert_eq!(result.1, "b");
+//     }
+// }
+
+// mod slice_matching {
+//     use std::vec;
+
+//     use super::*;
+
+//     #[unimock(api = Mock)]
+//     trait Trait {
+//         type X;
+
+//         type Y;
+
+//         fn vec_of_i32(&self, a: Vec<Self::X>);
+//         fn two_vec_of_i32(&self, a: Vec<Self::X>, b: Vec<Self::X>);
+//         fn vec_of_string(&self, a: Vec<Self::Y>);
+//     }
+
+//     #[test]
+//     fn vec_of_strings() {
+//         Unimock::<AssocType<_, AssocType<String>>>::with_assoc(
+//             Mock::vec_of_i32::<i32, String>
+//                 .next_call(matching!([1, 2]))
+//                 .returns(()),
+//         )
+//         .vec_of_i32(vec![1, 2]);
+//         Unimock::<AssocType<_, AssocType<String>>>::with_assoc(
+//             Mock::two_vec_of_i32::<i32, String>
+//                 .next_call(matching!([1, 2], [3, 4]))
+//                 .returns(()),
+//         )
+//         .two_vec_of_i32(vec![1, 2], vec![3, 4]);
+//         Unimock::<AssocType<i32, AssocType<_>>>::with_assoc(
+//             Mock::vec_of_string::<i32, String>
+//                 .next_call(matching!(([a, b]) if a == "1" && b == "2"))
+//                 .returns(()),
+//         )
+//         .vec_of_string(vec!["1".to_string(), "2".to_string()]);
+//     }
+// }
+
+// #[test]
+// fn eval_name_clash() {
+//     #[unimock(api = Mock, unmock_with=[unmock])]
+//     trait Trait {
+//         type X;
+
+//         fn tralala(&self, eval: Self::X);
+//     }
+
+//     fn unmock<X>(_: &impl std::any::Any, _: X) {}
+// }
+
+// #[test]
+// fn fn_cfg_attrs() {
+//     #[unimock(api = TraitMock)]
+//     trait Trait {
+//         type X;
+
+//         fn a(&self) -> Self::X;
+
+//         #[cfg(feature = "always-disabled")]
+//         fn b(&self) -> NonExistentType;
+//     }
+
+//     let u = Unimock::with_assoc(TraitMock::a::<i32>.next_call(matching!()).returns(0));
+//     assert_eq!(0, u.a());
+// }
+
+// mod output {
+//     use super::*;
+
+//     #[unimock(api=GenericOutputMock)]
+//     trait GenericOutput<T> {
+//         type X;
+//         fn generic_output(&self) -> T;
+//     }
+
+//     #[test]
+//     fn test_generic_return() {
+//         let deps: Unimock<AssocType<String>> = Unimock::with_assoc(
+//             GenericOutputMock::generic_output::<String>
+//                 .with_types::<String>()
+//                 .each_call(matching!())
+//                 .returns("success".to_string()),
+//         );
+
+//         let output = <Unimock<_> as GenericOutput<String>>::generic_output(&deps);
+//         assert_eq!("success", output);
+
+//         // let output = <Unimock as GenericOutput<i32>>::generic_output(&deps);
+//         // assert_eq!(42, output);
+//     }
+// }
+
+// mod param {
+//     use super::*;
+//     use std::fmt::Debug;
+
+//     #[unimock(api=GenericParamMock)]
+//     trait GenericParam<T> {
+//         type X;
+//         fn generic_param(&self, param: T) -> &'static str;
+//     }
+
+//     #[test]
+//     fn test_generic_param() {
+//         let deps: Unimock<AssocType<i32>> = Unimock::with_assoc((
+//             GenericParamMock::generic_param::<i32>
+//                 .with_types::<&'static str>()
+//                 .each_call(matching!("foobar"))
+//                 .returns("a string"),
+//             GenericParamMock::generic_param::<i32>
+//                 .with_types::<i32>()
+//                 .each_call(matching!(42))
+//                 .returns("a number"),
+//         ));
+
+//         assert_eq!("a string", deps.generic_param("foobar"));
+//         assert_eq!("a number", deps.generic_param(42_i32));
+//     }
+
+//     #[test]
+//     #[should_panic(
+//         // Since the generic parameter has no Debug bound, we cannot see the parameter:
+//         expected = "GenericParam::generic_param(?): No matching call patterns."
+//     )]
+//     fn test_generic_param_panic_no_debug() {
+//         let deps: Unimock<AssocType<i32>> = Unimock::with_assoc(
+//             GenericParamMock::generic_param::<i32>
+//                 .with_types::<i32>()
+//                 .each_call(matching!(1337))
+//                 .returns("a number"),
+//         );
+
+//         deps.generic_param(42_i32);
+//     }
+
+//     #[unimock(api=GenericParamDebugMock)]
+//     trait GenericParamDebug<T: Debug> {
+//         type X;
+//         fn generic_param_debug(&self, param: T) -> &'static str;
+//     }
+
+//     #[test]
+//     #[should_panic(
+//         // When it has a debug bound, we should see it:
+//         expected = "GenericParamDebug::generic_param_debug(42): No matching call patterns."
+//     )]
+//     fn test_generic_param_panic_debug() {
+//         let deps: Unimock<AssocType<i32>> = Unimock::with_assoc(
+//             GenericParamDebugMock::generic_param_debug::<i32>
+//                 .with_types::<i32>()
+//                 .each_call(matching!(1337))
+//                 .returns("a number"),
+//         );
+
+//         deps.generic_param_debug(42_i32);
+//     }
+// }
+
+// mod combined {
+//     use super::*;
+//     use std::fmt::Debug;
+
+//     #[unimock(api=A)]
+//     trait GenericBounds<I: Debug, O: Clone> {
+//         type X;
+//         fn generic_bounds(&self, param: I) -> O;
+//     }
+
+//     #[unimock(api=B)]
+//     trait GenericWhereBounds<I, O>
+//     where
+//         I: Debug,
+//         O: Clone,
+//     {
+//         type X;
+//         fn generic_where_bounds(&self, param: I) -> O;
+//     }
+// }
+
+// mod async_generic {
+//     use super::*;
+//     use std::fmt::Debug;
+
+//     #[unimock(api=A)]
+//     #[async_trait::async_trait(?Send)]
+//     trait AsyncTraitGenericBounds<I: Debug, O: Clone> {
+//         type X;
+//         async fn generic_bounds(&self, param: I) -> O;
+//     }
+// }
+
+// mod generic_without_module {
+//     use super::*;
+//     use std::fmt::Debug;
+
+//     #[unimock(api=[Func])]
+//     trait WithModule<T: Debug> {
+//         type X;
+//         fn func(&self) -> T;
+//     }
+
+//     #[test]
+//     fn mock() {
+//         Func::<i32>
+//             .with_types::<String>()
+//             .each_call(matching!())
+//             .returns("".to_string());
+//     }
+// }
+
+// mod generic_with_unmock {
+//     use super::*;
+
+//     // unmock is not implemented
+
+//     // #[unimock(unmock_with=[gen_default(self)])]
+//     // trait UnmockMe<T: Default> {
+//     //     type X;
+//     //     fn unmock_me(&self) -> T;
+//     // }
+
+//     // #[unimock(unmock_with=[gen_default(self)])]
+//     // trait UnmockMeWhere<T>
+//     // where
+//     //     T: Default,
+//     // {
+//     //     type X;
+//     //     fn unmock_me_where(&self) -> T;
+//     // }
+
+//     fn gen_default<D, T: Default>(_: &D) -> T {
+//         T::default()
+//     }
+// }
+
+// use unimock::*;
+
+// mod clone {
+
+//     #[derive(Eq, PartialEq, Debug)]
+//     pub struct Nope;
+
+//     #[derive(Clone, Eq, PartialEq, Debug)]
+//     pub struct Sure;
+// }
+
+// #[unimock(api=InOptionMock)]
+// trait InOption {
+//     type X;
+//     fn str(&self, a: &str) -> Option<&str>;
+//     fn not_clone(&self) -> Option<&clone::Nope>;
+// }
+
+// #[test]
+// fn in_option() {
+//     let u: Unimock<AssocType<()>> = Unimock::with_assoc((
+//         InOptionMock::str::<()>
+//             .next_call(matching!(_))
+//             .returns(Some("1".to_string())),
+//         InOptionMock::str::<()>
+//             .next_call(matching!(_))
+//             .returns(Some("2")),
+//         InOptionMock::str::<()>
+//             .next_call(matching!(_))
+//             .returns(None::<&str>),
+//     ));
+//     assert_eq!(Some("1"), u.str(""));
+//     assert_eq!(Some("2"), u.str(""));
+//     assert_eq!(None, u.str(""));
+// }
+
+// // This test demonstrates that a `T: Clone` bound is not necessary
+// // on each_call for `Option<&T>`, since the outer option
+// // can be generically reconstructed from the inner borrowed one
+// #[test]
+// fn in_option_not_clone_can_clone_anyway() {
+//     let u: Unimock<AssocType<()>> = Unimock::with_assoc(
+//         InOptionMock::not_clone::<()>
+//             .each_call(matching!())
+//             .returns(Some(clone::Nope)),
+//     );
+//     assert_eq!(Some(&clone::Nope), <Unimock<_> as InOption>::not_clone(&u));
+//     assert_eq!(Some(&clone::Nope), <Unimock<_> as InOption>::not_clone(&u));
+// }
+
+// #[unimock(api=InResultMock)]
+// trait InResult {
+//     type X;
+//     fn bytes(&self) -> Result<&[u8], clone::Nope>;
+//     fn u32_clone(&self) -> Result<&u32, clone::Sure>;
+//     fn ok_no_clone(&self, ok: bool) -> Result<&clone::Nope, clone::Sure>;
+//     fn err_no_clone(&self) -> Result<&clone::Nope, clone::Nope>;
+// }
+
+// #[test]
+// fn in_result() {
+//     let u: Unimock<AssocType<()>> = Unimock::with_assoc((
+//         InResultMock::bytes::<()>
+//             .next_call(matching!())
+//             .returns(Ok(vec![42])),
+//         InResultMock::bytes::<()>
+//             .next_call(matching!())
+//             .returns(Err::<&[u8], _>(clone::Nope)),
+//         InResultMock::u32_clone::<()>
+//             .each_call(matching!())
+//             .returns(Ok(42))
+//             .at_least_times(2),
+//     ));
+
+//     assert_eq!(Ok(vec![42].as_slice()), <Unimock<_> as InResult>::bytes(&u));
+//     assert_eq!(Err(clone::Nope), <Unimock<_> as InResult>::bytes(&u));
+//     assert_eq!(Ok(&42), <Unimock<_> as InResult>::u32_clone(&u));
+//     assert_eq!(Ok(&42), <Unimock<_> as InResult>::u32_clone(&u));
+// }
+
+// #[test]
+// fn in_result_clone_acrobatics() {
+//     let u: Unimock<AssocType<()>> = Unimock::with_assoc((
+//         InResultMock::ok_no_clone::<()>
+//             .each_call(matching!(true))
+//             .returns(Ok(clone::Nope)),
+//         InResultMock::ok_no_clone::<()>
+//             .each_call(matching!(false))
+//             .returns(Err::<&clone::Nope, _>(clone::Sure)),
+//         InResultMock::err_no_clone::<()>
+//             .some_call(matching!()) // note: .each_call is impossible
+//             .returns(Err::<&clone::Nope, _>(clone::Nope)),
+//     ));
+
+//     for _ in 0..3 {
+//         assert_eq!(Ok(&clone::Nope), u.ok_no_clone(true));
+//         assert_eq!(Err(clone::Sure), u.ok_no_clone(false));
+//     }
+
+//     assert_eq!(Err(clone::Nope), u.err_no_clone());
+// }
+
+// #[test]
+// #[should_panic(
+//     expected = "InResult::ok_no_clone: Expected InResult::ok_no_clone(_) at tests/it/assoc_types.rs:1105 to match exactly 1 call, but it actually matched 2 calls."
+// )]
+// fn in_result_may_multi_respond_on_ok_no_clone() {
+//     let u: Unimock<AssocType<()>> = Unimock::with_assoc(
+//         InResultMock::ok_no_clone::<()>
+//             .some_call(matching!(_))
+//             .returns(Ok(clone::Nope)),
+//     );
+
+//     assert_eq!(Ok(&clone::Nope), u.ok_no_clone(true));
+//     assert_eq!(Ok(&clone::Nope), u.ok_no_clone(true));
+// }
+
+// #[unimock(api = InVecMock)]
+// trait InVec {
+//     type X;
+//     fn vector(&self) -> Vec<&i32>;
+// }
+
+// #[test]
+// fn in_vec() {
+//     let u: Unimock<AssocType<()>> = Unimock::with_assoc(
+//         InVecMock::vector::<()>
+//             .each_call(matching!())
+//             .returns(vec![1, 2, 3]),
+//     );
+
+//     assert_eq!(vec![&1, &2, &3], u.vector());
+// }
+
+// #[unimock(api = MixedTupleMock)]
+// trait MixedTuple {
+//     type X;
+//     fn tuple1(&self) -> (&i32,);
+//     fn tuple2a(&self) -> (&i32, i32);
+//     fn tuple2b(&self) -> (i32, &i32);
+//     fn tuple4(&self) -> (&clone::Nope, clone::Nope, &clone::Sure, clone::Sure);
+// }
+
+// #[test]
+// fn mixed_tuple1() {
+//     let u: Unimock<AssocType<()>> = Unimock::with_assoc((
+//         MixedTupleMock::tuple2a::<()>
+//             .next_call(matching!())
+//             .returns((1, 2)),
+//         MixedTupleMock::tuple2b::<()>
+//             .next_call(matching!())
+//             .returns((1, 2)),
+//     ));
+
+//     assert_eq!((&1, 2), u.tuple2a());
+//     assert_eq!((1, &2), u.tuple2b());
+// }
+
+// #[test]
+// fn mixed_tuple_clone_combinatorics_once() {
+//     let u: Unimock<AssocType<()>> = Unimock::with_assoc(
+//         MixedTupleMock::tuple4::<()>
+//             .next_call(matching!())
+//             .returns((clone::Nope, clone::Nope, clone::Sure, clone::Sure)),
+//     );
+
+//     assert_eq!(
+//         (&clone::Nope, clone::Nope, &clone::Sure, clone::Sure),
+//         u.tuple4()
+//     );
+// }
+
+// #[test]
+// fn mixed_tuple_clone_combinatorics_many() {
+//     let u: Unimock<AssocType<()>> = Unimock::with_assoc(
+//         MixedTupleMock::tuple4::<()>
+//             .each_call(matching!())
+//             .answers(|_| (clone::Nope, clone::Nope, clone::Sure, clone::Sure)),
+//     );
+
+//     for _ in 0..3 {
+//         assert_eq!(
+//             (&clone::Nope, clone::Nope, &clone::Sure, clone::Sure),
+//             u.tuple4()
+//         );
+//     }
+// }
 
 mod complex {
     use async_trait::async_trait;
     use unimock::*;
 
-    #[unimock(api=CrazyMock)]
-    #[async_trait(?Send)]
-    trait Crazy<'x, T> {
-        type Ok;
+    // #[unimock(api=CrazyMock)]
+    // #[async_trait(?Send)]
+    // trait Crazy<'x, T> {
+    //     type Ok;
 
-        type Err;
+    //     type Err;
 
-        async fn thing(&'x self, arg: T) -> Result<Self::Ok, Self::Err>;
-    }
+    //     async fn thing(&'x self, arg: T) -> Result<Self::Ok, Self::Err>;
+    // }
 
-    #[tokio::test]
-    async fn crazy() {
-        let u = Unimock::with_assoc(
-            CrazyMock::thing::<i32, String>
-                .with_types::<u32>()
-                .next_call(matching!(666_666))
-                .returns(Ok(42)),
-        );
+    // #[tokio::test]
+    // async fn crazy() {
+    //     let u = Unimock::with_assoc(
+    //         CrazyMock::thing::<i32, String>
+    //             .with_types::<u32>()
+    //             .next_call(matching!(666_666))
+    //             .returns(Ok(42)),
+    //     );
 
-        assert_eq!(Ok::<_, String>(42), u.thing(666_666u32).await);
-    }
+    //     assert_eq!(Ok::<_, String>(42), u.thing(666_666u32).await);
+    // }
 
     #[unimock(api=EvenCrazierMock)]
     #[async_trait(?Send)]
@@ -1232,3 +1232,116 @@ mod complex {
         assert_eq!(Ok::<_, String>("42"), u.thing2((), &666_666u32).await);
     }
 }
+
+// Recursive expansion of unimock! macro
+// ======================================
+
+#[async_trait(?Send)]
+trait EvenCrazier<'x, T: Default, Unit = ()>
+where
+    T: ?Sized,
+{
+    type Ok: Into<Self::Err>;
+
+    type Err: std::fmt::Display + 'static;
+
+    async fn thing2(&'x self, other: Unit, arg: &T) -> Result<Self::Ok, Self::Err>;
+}
+#[doc = "Unimock setup module for `EvenCrazier`"]
+#[allow(non_snake_case)]
+mod EvenCrazierMock {
+    #[allow(non_camel_case_types)]
+    #[doc = "Generic mock interface for `EvenCrazier::thing2(other: Unit, arg: &T) -> Result<Ok, Err>`. Get a MockFn instance by calling `with_types()`."]
+    #[allow(unused)]
+    #[::unimock::macro_api::phantom] ////////////////////////// add phantom
+    pub struct thing2<Ok: Into<Err>, Err: std::fmt::Display + 'static>; ////////////////////// assoc types as params
+}
+const _: () = {
+    impl<Ok: Into<Err> + Send +'static, Err: std::fmt::Display + 'static + Send> EvenCrazierMock::thing2<Ok, Err> { //////////////////// assoc types as params with +'static+Send; as args 
+        pub fn with_types<T: Default + 'static + Send, Unit: 'static + Send>( /////////////////////// remove default
+            self,
+        ) -> impl for<'__i> ::unimock::MockFn<
+            Inputs<'__i> = (Unit, &'__i T),
+            Response = ::unimock::output::Owned<Result<Ok, Err>>,
+        >
+        where
+            T: ?Sized,
+        {
+            __Genericthing2(::core::marker::PhantomData, ::core::marker::PhantomData, ::core::marker::PhantomData, ::core::marker::PhantomData)
+        }
+    }
+    #[allow(non_camel_case_types)]
+    struct __Genericthing2<T, Unit, Ok, Err>( ///////////// generics + assoc types as args
+        ::core::marker::PhantomData<T>,
+        ::core::marker::PhantomData<Unit>,
+        ::core::marker::PhantomData<Ok>, //////////// add them
+        ::core::marker::PhantomData<Err>, //////////// add them
+    );
+
+    impl<T: Default + 'static + Send, Unit: 'static + Send, Ok: 'static + Send, Err: 'static + Send> ::unimock::MockFn ///////////////// assoc types as args + 'static + Send
+        for __Genericthing2<T, Unit, Ok, Err> ///////////////// generics + assoc types as args
+    where
+        T: ?Sized,
+    {
+        type Inputs<'__i> = (Unit, &'__i T);
+        type Response = ::unimock::output::Owned<Result<Ok, Err>>;
+        type Output<'u> = Self::Response;
+        const NAME: &'static str = "EvenCrazier::thing2";
+        fn debug_inputs((other, arg): &Self::Inputs<'_>) -> String {
+            use ::unimock::macro_api::{NoDebug, ProperDebug};
+            ::unimock::macro_api::format_inputs(&[
+                other.unimock_try_debug(),
+                (*arg).unimock_try_debug(),
+            ])
+        }
+    }
+    impl<'x, T: Default + 'static + Send, Unit: 'static + Send, Ok: Into<Err> + Send + 'static, Err: std::fmt::Display + 'static + Send> EvenCrazier<'x, T, Unit> /////////////// generics + assoc types as params +'static+Send
+        for ::unimock::Unimock<::unimock::AssocType<Ok, ::unimock::AssocType<Err>>> //////////////// hlist
+    where
+        T: ?Sized,
+    {
+        type Ok = Ok; //////////////// add them
+        type Err = Err; //////////////// add them
+        #[track_caller]
+        #[allow(
+            clippy::let_unit_value,
+            clippy::no_effect_underscore_binding,
+            clippy::shadow_same,
+            clippy::type_complexity,
+            clippy::type_repetition_in_bounds,
+            clippy::used_underscore_binding
+        )]
+        fn thing2<'life0, 'async_trait>(
+            &'x self,
+            other: Unit,
+            arg: &'life0 T,
+        ) -> ::core::pin::Pin<
+            Box<dyn ::core::future::Future<Output = Result<Self::Ok, Self::Err>> + 'async_trait>,
+        >
+        where
+            'life0: 'async_trait,
+            Self: 'async_trait,
+            'x: 'async_trait ////////////// bound
+        {
+            Box::pin(async move {
+                if let ::core::option::Option::Some(__ret) =
+                    ::core::option::Option::None::<Result<Self::Ok, Self::Err>>
+                {
+                    return __ret;
+                }
+                let __self = self;
+                let other = other;
+                let arg = arg;
+                let __ret: Result<Self::Ok, Self::Err> = {
+                    ::unimock::macro_api::eval::<__Genericthing2::<T, Unit, Ok, Err>, _>( ///////////////// generics + assoc types as args
+                        &__self,
+                        (other, arg),
+                    )
+                    .unwrap(&__self)
+                };
+                #[allow(unreachable_code)]
+                __ret
+            })
+        }
+    }
+};

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -1,14 +1,14 @@
 mod assoc_types;
-// mod basic;
-// mod errors;
-// mod generic;
-// mod matching_eq;
-// mod matching_pat;
-// mod mixed;
-// mod mock_order;
-// mod prefix;
-// #[cfg(feature = "pretty-print")]
-// mod pretty_mismatches;
-// mod unmock;
+mod basic;
+mod errors;
+mod generic;
+mod matching_eq;
+mod matching_pat;
+mod mixed;
+mod mock_order;
+mod prefix;
+#[cfg(feature = "pretty-print")]
+mod pretty_mismatches;
+mod unmock;
 
 fn main() {}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -1,3 +1,4 @@
+mod assoc_types;
 mod basic;
 mod errors;
 mod generic;

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -1,14 +1,14 @@
 mod assoc_types;
-mod basic;
-mod errors;
-mod generic;
-mod matching_eq;
-mod matching_pat;
-mod mixed;
-mod mock_order;
-mod prefix;
-#[cfg(feature = "pretty-print")]
-mod pretty_mismatches;
-mod unmock;
+// mod basic;
+// mod errors;
+// mod generic;
+// mod matching_eq;
+// mod matching_pat;
+// mod mixed;
+// mod mock_order;
+// mod prefix;
+// #[cfg(feature = "pretty-print")]
+// mod pretty_mismatches;
+// mod unmock;
 
 fn main() {}

--- a/unimock_macros/Cargo.toml
+++ b/unimock_macros/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/audunhalland/unimock/"
 keywords = ["procedural-macro", "macros"]
 
 [dependencies]
-syn = { version = "1.0.75", features = ["full", "visit-mut"] }
+syn = { version = "1.0.75", features = ["full", "visit-mut", "extra-traits"] }
 quote = "1"
 proc-macro2 = "1"
 

--- a/unimock_macros/src/unimock/mod.rs
+++ b/unimock_macros/src/unimock/mod.rs
@@ -1,4 +1,4 @@
-use quote::quote;
+use quote::{quote, ToTokens};
 
 mod associated_future;
 mod attr;
@@ -12,6 +12,7 @@ use trait_info::TraitInfo;
 
 use attr::{UnmockFn, UnmockFnParams};
 
+#[allow(clippy::too_many_lines)]
 pub fn generate(attr: Attr, item_trait: syn::ItemTrait) -> syn::Result<proc_macro2::TokenStream> {
     let trait_info = trait_info::TraitInfo::analyze(&attr.prefix, &item_trait, &attr)?;
     attr.validate(&trait_info)?;
@@ -42,6 +43,14 @@ pub fn generate(attr: Attr, item_trait: syn::ItemTrait) -> syn::Result<proc_macr
         .methods
         .iter()
         .filter_map(|method| associated_future::def_associated_future(method.as_ref()));
+    let associated_types = trait_info.item.items.iter().filter_map(|item| {
+        if let syn::TraitItem::Type(ty) = item {
+            let ident = &ty.ident;
+            Some(quote! { type #ident = #ident; })
+        } else {
+            None
+        }
+    });
     let method_impls = trait_info
         .methods
         .iter()
@@ -57,8 +66,16 @@ pub fn generate(attr: Attr, item_trait: syn::ItemTrait) -> syn::Result<proc_macr
         .iter()
         .filter_map(Option::as_ref)
         .map(|def| &def.impl_details);
-    let generic_params = util::Generics::params(&trait_info);
+    let generic_params_assoc = util::Generics::params_with_assoc_types(&trait_info);
     let generic_args = util::Generics::args(&trait_info);
+
+    let unimock_generics = make_generics_hlist(trait_info.item.items.iter().filter_map(|item| {
+        if let syn::TraitItem::Type(ty) = item {
+            Some(ty.ident.clone())
+        } else {
+            None
+        }
+    }));
 
     let (opt_mock_interface_public, opt_mock_interface_private) = match &attr.mock_api {
         MockApi::Hidden => (
@@ -101,12 +118,37 @@ pub fn generate(attr: Attr, item_trait: syn::ItemTrait) -> syn::Result<proc_macr
             #(#mock_fn_impl_details)*
 
             #(#impl_attributes)*
-            impl #generic_params #trait_ident #generic_args for #prefix::Unimock #where_clause {
+            impl #generic_params_assoc #trait_ident #generic_args
+                for #prefix::Unimock<#unimock_generics>
+            #where_clause
+            {
                 #(#associated_futures)*
+                #(#associated_types)*
                 #(#method_impls)*
             }
         };
     })
+}
+
+fn make_generics_hlist(idents: impl Iterator<Item = syn::Ident>) -> proc_macro2::TokenStream {
+    let mut tokens = proc_macro2::TokenStream::new();
+
+    let assoc_type = quote! { ::unimock::AssocType };
+
+    let mut i = 0;
+    for ident in idents {
+        i += 1;
+        assoc_type.to_tokens(&mut tokens);
+        syn::token::Lt::default().to_tokens(&mut tokens);
+        ident.to_tokens(&mut tokens);
+        syn::token::Comma::default().to_tokens(&mut tokens);
+    }
+
+    for _ in 0..i {
+        syn::token::Gt::default().to_tokens(&mut tokens);
+    }
+
+    tokens
 }
 
 struct MockFnDef {
@@ -114,6 +156,7 @@ struct MockFnDef {
     impl_details: proc_macro2::TokenStream,
 }
 
+#[allow(clippy::too_many_lines)]
 fn def_mock_fn(
     method: Option<&method::MockMethod>,
     trait_info: &TraitInfo,
@@ -145,14 +188,21 @@ fn def_mock_fn(
             syn::FnArg::Receiver(_) => None,
             syn::FnArg::Typed(pat_type) => match (index, pat_type.pat.as_ref()) {
                 (0, syn::Pat::Ident(pat_ident)) if pat_ident.ident == "self" => None,
-                _ => Some(pat_type.ty.as_ref()),
+                _ => {
+                    let mut new = pat_type.ty.clone();
+                    util::remove_self_nested_type(&mut new);
+                    Some(new)
+                }
             },
         })
-        .map(|ty| util::substitute_lifetimes(ty, input_lifetime))
+        .map(|ty| util::substitute_lifetimes(&ty, input_lifetime))
         .collect::<Vec<_>>();
 
     let generic_params = util::Generics::params(trait_info);
-    let generic_args = util::Generics::args(trait_info);
+    let generic_params_with_assoc_types = util::Generics::params_with_assoc_types(trait_info);
+    let generic_args_with_assoc_types = util::Generics::args_with_assoc_types(trait_info);
+    let assoc_types = util::Generics::params_assoc_types(trait_info);
+    let assoc_types_no_bounds = util::Generics::args_assoc_types(trait_info);
     let where_clause = &trait_info.item.generics.where_clause;
 
     let doc_attrs = if matches!(attr.mock_api, attr::MockApi::Hidden) {
@@ -166,17 +216,31 @@ fn def_mock_fn(
 
     let debug_inputs_fn = method.generate_debug_inputs_fn(attr);
 
-    let gen_mock_fn_struct_item = |non_generic_ident: &syn::Ident| {
+    let gen_mock_fn_struct_item = |non_generic_ident: &syn::Ident, assoc_types: &util::Generics| {
+        let ghost = assoc_types
+            .trait_info()
+            .item
+            .items
+            .iter()
+            .any(|item| matches!(item, syn::TraitItem::Type(_)))
+            .then(|| {
+                quote! {
+                    #[allow(dead_code)]
+                    #[::unimock::macro_api::phantom]
+                }
+            });
         quote! {
             #[allow(non_camel_case_types)]
             #(#doc_attrs)*
-            #mock_visibility struct #non_generic_ident;
+            #[allow(unused_)]
+            #ghost
+            #mock_visibility struct #non_generic_ident #assoc_types;
         }
     };
 
     let impl_blocks = quote! {
         #(#mirrored_attrs)*
-        impl #generic_params #prefix::MockFn for #mock_fn_path #generic_args #where_clause {
+        impl #generic_params_with_assoc_types #prefix::MockFn for #mock_fn_path #generic_args_with_assoc_types #where_clause {
             type Inputs<#input_lifetime> = (#(#inputs_tuple),*);
             type Response = #response_associated_type;
             type Output<'u> = #output_associated_type;
@@ -189,18 +253,16 @@ fn def_mock_fn(
     let mock_fn_def = if let Some(non_generic_ident) = &method.non_generic_mock_entry_ident {
         // the trait is generic
         let phantoms_tuple = util::MockFnPhantomsTuple(trait_info);
-        let untyped_phantoms = trait_info
-            .generic_type_params()
-            .map(|_| util::UntypedPhantomData);
+        let untyped_phantom = util::UntypedPhantomData;
         let module_scope = match &attr.mock_api {
             MockApi::MockMod(ident) => Some(quote! { #ident:: }),
             _ => None,
         };
 
         MockFnDef {
-            mock_fn_struct_item: gen_mock_fn_struct_item(non_generic_ident),
+            mock_fn_struct_item: gen_mock_fn_struct_item(non_generic_ident, &assoc_types),
             impl_details: quote! {
-                impl #module_scope #non_generic_ident {
+                impl #assoc_types #module_scope #non_generic_ident #assoc_types_no_bounds {
                     pub fn with_types #generic_params(
                         self
                     ) -> impl for<#input_lifetime> #prefix::MockFn<
@@ -209,19 +271,19 @@ fn def_mock_fn(
                     >
                         #where_clause
                     {
-                        #mock_fn_ident(#(#untyped_phantoms),*)
+                        #mock_fn_ident :: #generic_args_with_assoc_types (#untyped_phantom)
                     }
                 }
 
                 #[allow(non_camel_case_types)]
-                struct #mock_fn_ident #generic_args #phantoms_tuple;
+                struct #mock_fn_ident #generic_params_with_assoc_types #phantoms_tuple;
 
                 #impl_blocks
             },
         }
     } else {
         MockFnDef {
-            mock_fn_struct_item: gen_mock_fn_struct_item(mock_fn_ident),
+            mock_fn_struct_item: gen_mock_fn_struct_item(mock_fn_ident, &assoc_types),
             impl_details: impl_blocks,
         }
     };
@@ -246,7 +308,7 @@ fn def_method_impl(
     let mock_fn_path = method.mock_fn_path(attr);
 
     let inputs_destructuring = method.inputs_destructuring();
-    let generic_args = util::Generics::args(trait_info);
+    let generic_args_assoc = util::Generics::args_with_assoc_types(trait_info);
 
     let has_impl_trait_future = matches!(
         method.output_structure.wrapping,
@@ -274,14 +336,14 @@ fn def_method_impl(
         };
 
         quote! {
-            match #prefix::macro_api::eval::<#mock_fn_path #generic_args>(&self, (#inputs_destructuring)) {
+            match #prefix::macro_api::eval::<#mock_fn_path #generic_args_assoc, _>(&self, (#inputs_destructuring)) {
                 #prefix::macro_api::Evaluation::Evaluated(output) => output,
                 #prefix::macro_api::Evaluation::Skipped((#inputs_destructuring)) => #unmock_expr
             }
         }
     } else {
         quote! {
-            #prefix::macro_api::eval::<#mock_fn_path #generic_args>(&self, (#inputs_destructuring)).unwrap(&self)
+            #prefix::macro_api::eval::<#mock_fn_path #generic_args_assoc, _>(&self, (#inputs_destructuring)).unwrap(&self)
         }
     };
 

--- a/unimock_macros/src/unimock/mod.rs
+++ b/unimock_macros/src/unimock/mod.rs
@@ -109,11 +109,13 @@ pub fn generate(attr: Attr, item_trait: syn::ItemTrait) -> syn::Result<proc_macr
         ),
     };
 
-    let unimock_generics =
-        make_generics_hlist(trait_info.item.items.iter().filter_map(|item| match item {
+    let unimock_generics = make_generics_hlist(
+        prefix,
+        trait_info.item.items.iter().filter_map(|item| match item {
             syn::TraitItem::Type(ty) => Some(&ty.ident),
             _ => None,
-        }));
+        }),
+    );
     let associated_types = trait_info.item.items.iter().filter_map(|item| {
         if let syn::TraitItem::Type(ty) = item {
             let ident = &ty.ident;
@@ -143,11 +145,12 @@ pub fn generate(attr: Attr, item_trait: syn::ItemTrait) -> syn::Result<proc_macr
 }
 
 fn make_generics_hlist<'i>(
+    prefix: &syn::Path,
     idents: impl Iterator<Item = &'i syn::Ident>,
 ) -> proc_macro2::TokenStream {
     let mut tokens = proc_macro2::TokenStream::new();
 
-    let assoc_type = quote! { ::unimock::AssocType };
+    let assoc_type = quote! { #prefix::AssocType };
 
     let mut i = 0;
     for ident in idents {

--- a/unimock_macros/src/unimock/output.rs
+++ b/unimock_macros/src/unimock/output.rs
@@ -32,6 +32,8 @@ impl OutputStructure {
                 quote! { () }
             }
             AssociatedInnerType::Typed(inner_type) => {
+                let mut inner_type = inner_type.clone();
+                util::remove_self_nested_type(&mut inner_type);
                 quote! { #inner_type }
             }
         };

--- a/unimock_macros/src/unimock/output.rs
+++ b/unimock_macros/src/unimock/output.rs
@@ -320,6 +320,7 @@ fn find_param_lifetime(sig: &syn::Signature, lifetime_ident: &syn::Ident) -> Opt
     None
 }
 
+#[derive(Clone)]
 enum AssociatedInnerType {
     Unit,
     Typed(syn::Type),

--- a/unimock_macros/src/unimock/trait_info.rs
+++ b/unimock_macros/src/unimock/trait_info.rs
@@ -46,6 +46,7 @@ impl<'t> TraitInfo<'t> {
             for generic_param in generic_params.iter() {
                 if let syn::GenericParam::Type(type_param) = generic_param {
                     let mut bounded_param = type_param.clone();
+                    bounded_param.default = None;
 
                     add_static_bound_if_not_present(&mut bounded_param);
                     if contains_async {

--- a/unimock_macros/src/unimock/util.rs
+++ b/unimock_macros/src/unimock/util.rs
@@ -38,6 +38,7 @@ fn is_type_generic(trait_info: &TraitInfo, method: Option<&MockMethod<'_>>) -> b
 }
 
 impl<'t> Generics<'t> {
+    // Generics and Associated types as params
     pub fn all_params(trait_info: &'t TraitInfo, method: Option<&'t MockMethod<'t>>) -> Self {
         Self {
             trait_info,
@@ -76,6 +77,7 @@ impl<'t> Generics<'t> {
         }
     }
 
+    // Associated types as params
     pub fn assoc_types_params(
         trait_info: &'t TraitInfo,
         method: Option<&'t MockMethod<'t>>,
@@ -87,6 +89,7 @@ impl<'t> Generics<'t> {
         }
     }
 
+    // Associated types as args
     pub fn assoc_types_args(trait_info: &'t TraitInfo, method: Option<&'t MockMethod<'t>>) -> Self {
         Self {
             trait_info,
@@ -173,8 +176,18 @@ impl<'t> quote::ToTokens for Generics<'t> {
                     .generic_params_with_bounds
                     .params
                     .to_tokens(tokens);
+                if !self.trait_info.generic_params_with_bounds.params.is_empty() {
+                    quote! { , }.to_tokens(tokens);
+                }
                 if let Some(method) = self.method {
                     method.generic_params_with_bounds.params.to_tokens(tokens);
+                }
+                if self
+                    .method
+                    .map(|m| !m.generic_params_with_bounds.params.is_empty())
+                    .unwrap_or_default()
+                {
+                    quote! { , }.to_tokens(tokens);
                 }
             }
             GenericsKind::Args(infer_impl_trait) => {

--- a/unimock_macros/src/unimock/util.rs
+++ b/unimock_macros/src/unimock/util.rs
@@ -9,8 +9,12 @@ pub struct Generics<'t> {
 
 enum GenericsKind {
     None,
+    AssocTypesWithBounds,
+    AssocTypesNoBounds,
     GenericParams,
+    GenericParamsWithAssocTypes,
     Args,
+    ArgsWithAssocTypes,
 }
 
 impl<'t> Generics<'t> {
@@ -26,6 +30,34 @@ impl<'t> Generics<'t> {
         }
     }
 
+    // Like `Self::params` but with assoc types
+    pub fn params_with_assoc_types(trait_info: &'t TraitInfo) -> Self {
+        Self {
+            trait_info,
+            kind: if trait_info.is_type_generic {
+                GenericsKind::GenericParamsWithAssocTypes
+            } else {
+                GenericsKind::AssocTypesWithBounds
+            },
+        }
+    }
+
+    // Like `Self::params` but with assoc types
+    pub fn params_assoc_types(trait_info: &'t TraitInfo) -> Self {
+        Self {
+            trait_info,
+            kind: GenericsKind::AssocTypesWithBounds,
+        }
+    }
+
+    // Like `Self::params` but with assoc types
+    pub fn args_assoc_types(trait_info: &'t TraitInfo) -> Self {
+        Self {
+            trait_info,
+            kind: GenericsKind::AssocTypesNoBounds,
+        }
+    }
+
     // Args: e.g. SomeType<A, B>
     pub fn args(trait_info: &'t TraitInfo) -> Self {
         Self {
@@ -34,6 +66,18 @@ impl<'t> Generics<'t> {
                 GenericsKind::Args
             } else {
                 GenericsKind::None
+            },
+        }
+    }
+
+    // Args: e.g. SomeType<A, B>
+    pub fn args_with_assoc_types(trait_info: &'t TraitInfo) -> Self {
+        Self {
+            trait_info,
+            kind: if trait_info.is_type_generic {
+                GenericsKind::ArgsWithAssocTypes
+            } else {
+                GenericsKind::AssocTypesNoBounds
             },
         }
     }
@@ -58,6 +102,10 @@ impl<'t> Generics<'t> {
                 }
             })
     }
+
+    pub fn trait_info(&self) -> &TraitInfo {
+        self.trait_info
+    }
 }
 
 impl<'t> quote::ToTokens for Generics<'t> {
@@ -69,13 +117,66 @@ impl<'t> quote::ToTokens for Generics<'t> {
         syn::token::Lt::default().to_tokens(tokens);
         match &self.kind {
             GenericsKind::None => {}
+            GenericsKind::AssocTypesWithBounds => {
+                for item in &self.trait_info.item.items {
+                    if let syn::TraitItem::Type(ty) = item {
+                        ty.ident.to_tokens(tokens);
+                        if ty.bounds.is_empty() {
+                            quote! { : 'static }.to_tokens(tokens);
+                        } else {
+                            syn::token::Colon::default().to_tokens(tokens);
+                            ty.bounds.to_tokens(tokens);
+                            quote! { + 'static }.to_tokens(tokens);
+                        }
+                        syn::token::Comma::default().to_tokens(tokens);
+                    }
+                }
+            }
+            GenericsKind::AssocTypesNoBounds => {
+                for item in &self.trait_info.item.items {
+                    if let syn::TraitItem::Type(ty) = item {
+                        ty.ident.to_tokens(tokens);
+                        syn::token::Comma::default().to_tokens(tokens);
+                    }
+                }
+            }
             GenericsKind::GenericParams => {
                 self.trait_info.generic_params_with_bounds.to_tokens(tokens);
+            }
+            GenericsKind::GenericParamsWithAssocTypes => {
+                self.trait_info.generic_params_with_bounds.to_tokens(tokens);
+                for item in &self.trait_info.item.items {
+                    if let syn::TraitItem::Type(ty) = item {
+                        syn::token::Comma::default().to_tokens(tokens);
+                        ty.ident.to_tokens(tokens);
+                        if ty.bounds.is_empty() {
+                            quote! { : 'static }.to_tokens(tokens);
+                        } else {
+                            ty.bounds.to_tokens(tokens);
+                            quote! { + 'static }.to_tokens(tokens);
+                        }
+                    }
+                }
             }
             GenericsKind::Args => {
                 let args = self.args_iterator();
                 quote! {
                     #(#args),*
+                }
+                .to_tokens(tokens);
+            }
+            GenericsKind::ArgsWithAssocTypes => {
+                let args = self.args_iterator();
+
+                let assoc = self.trait_info.item.items.iter().filter_map(|i| {
+                    if let syn::TraitItem::Type(ty) = i {
+                        Some(&ty.ident)
+                    } else {
+                        None
+                    }
+                });
+                quote! {
+                    #(#args),*, #(#assoc),*
                 }
                 .to_tokens(tokens);
             }
@@ -89,18 +190,22 @@ pub struct MockFnPhantomsTuple<'t>(pub &'t TraitInfo<'t>);
 impl<'t> quote::ToTokens for MockFnPhantomsTuple<'t> {
     fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
         if self.0.is_type_generic {
-            let phantom_data = self
+            let types = self
                 .0
                 .generic_type_params()
-                .map(TypedPhantomData)
+                .map(|ty| &ty.ident)
+                .chain(self.0.item.items.iter().filter_map(|item| {
+                    if let syn::TraitItem::Type(ty) = item {
+                        Some(&ty.ident)
+                    } else {
+                        None
+                    }
+                }))
                 .collect::<Vec<_>>();
 
-            if !phantom_data.is_empty() {
-                quote! {
-                    (#(#phantom_data),*)
-                }
-                .to_tokens(tokens);
-            }
+            let phantom_data = TypedPhantomData(&types);
+
+            quote! { (#phantom_data) }.to_tokens(tokens);
         }
     }
 }
@@ -116,13 +221,13 @@ impl quote::ToTokens for UntypedPhantomData {
     }
 }
 
-pub struct TypedPhantomData<'t>(&'t syn::TypeParam);
+pub struct TypedPhantomData<'t>(&'t [&'t syn::Ident]);
 
 impl<'t> quote::ToTokens for TypedPhantomData<'t> {
     fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
-        let ident = &self.0.ident;
+        let idents = self.0.iter();
         quote! {
-            ::core::marker::PhantomData<#ident>
+            ::core::marker::PhantomData<(#(#idents),*)>
         }
         .to_tokens(tokens);
     }
@@ -161,5 +266,86 @@ impl quote::ToTokens for DotAwait {
         use proc_macro2::*;
         tokens.append(Punct::new('.', Spacing::Alone));
         tokens.append(quote::format_ident!("await"));
+    }
+}
+
+pub fn remove_self_in_segment(
+    p: syn::punctuated::Punctuated<syn::PathSegment, syn::token::Colon2>,
+) -> syn::punctuated::Punctuated<syn::PathSegment, syn::token::Colon2> {
+    p.into_iter()
+        .filter_map(|mut seg| {
+            (!is_self_segment(Some(&seg))).then(|| {
+                match &mut seg.arguments {
+                    syn::PathArguments::None => {}
+                    syn::PathArguments::AngleBracketed(ab) => {
+                        for arg in ab.args.iter_mut() {
+                            if let syn::GenericArgument::Type(ty) = arg {
+                                remove_self_nested_type(ty);
+                            }
+                        }
+                    }
+                    syn::PathArguments::Parenthesized(p) => {
+                        for inp in &mut p.inputs {
+                            remove_self_nested_type(inp);
+                        }
+                        if let syn::ReturnType::Type(_, ty) = &mut p.output {
+                            remove_self_nested_type(ty.as_mut());
+                        }
+                    }
+                };
+                seg
+            })
+        })
+        .collect()
+}
+
+pub fn remove_self_nested_type(ty: &mut syn::Type) {
+    match ty {
+        syn::Type::Array(arr) => remove_self_nested_type(&mut arr.elem),
+        syn::Type::Tuple(tup) => {
+            for ty in &mut tup.elems {
+                remove_self_nested_type(ty);
+            }
+        }
+        syn::Type::BareFn(f) => {
+            for inp in &mut f.inputs {
+                remove_self_nested_type(&mut inp.ty);
+            }
+            if let syn::ReturnType::Type(_, ty) = &mut f.output {
+                remove_self_nested_type(ty.as_mut());
+            }
+        }
+        syn::Type::Group(g) => remove_self_nested_type(&mut g.elem),
+        syn::Type::Paren(p) => remove_self_nested_type(&mut p.elem),
+        syn::Type::Path(p) => p.path.segments = remove_self_in_segment(p.path.segments.clone()),
+        syn::Type::Ptr(ptr) => remove_self_nested_type(&mut ptr.elem),
+        syn::Type::Reference(r) => remove_self_nested_type(&mut r.elem),
+        syn::Type::Slice(sl) => remove_self_nested_type(&mut sl.elem),
+        syn::Type::ImplTrait(imp) => {
+            for bound in &mut imp.bounds {
+                if let syn::TypeParamBound::Trait(ref mut t) = bound {
+                    t.path.segments = remove_self_in_segment(t.path.segments.clone());
+                }
+            }
+        }
+        syn::Type::TraitObject(to) => {
+            for bound in &mut to.bounds {
+                if let syn::TypeParamBound::Trait(ref mut t) = bound {
+                    t.path.segments = remove_self_in_segment(t.path.segments.clone());
+                }
+            }
+        }
+        syn::Type::Infer(_)
+        | syn::Type::Macro(_)
+        | syn::Type::Never(_)
+        | syn::Type::Verbatim(_) => {}
+        _ => unimplemented!(),
+    }
+}
+
+pub fn is_self_segment(segment: Option<&syn::PathSegment>) -> bool {
+    match segment {
+        None => false,
+        Some(segment) => segment.ident == "Self",
     }
 }


### PR DESCRIPTION
Resolves #17 :)

# Synopsis

Provide a way to mock traits with associated types besides futures.

# Solution

`unimock` currently states that "Unimock would have to select a type at random, which does not make a lot of sense.", but there is a better way.

We can parameterize structs that `#[unimock]` generates for trait's functions with a generic types, one for each associated type from trait definition. The user would be able to choose a concrete type for an implementation when instantiating `Unimock`.

But, you may ask, how can `Unimock` be _generic_ over associated types? Isn't the whole point of traits containing associated types in that there can only be one `impl` of such trait? And how would adding a generics to mock `fn`s help `Unimock`? Does this all mean `Unimock` will too need to be generic over all of the possible associated types? How?

To that I will answer with...

# The tricks

First, the generics on `Unimock`. We don't need one generic per associated type here. We can use heterogeneous lists tehnique:

```rust
// in `unimock`

pub struct NoAssocType;
pub struct AssocType<T: ?Sized, Next = NoAssocType>(PhantomData<(Next, T)>);
pub struct Unimock<Assoc = NoAssocType> {
    ...
    _m: PhantomData<Assoc>,
}

// in tests

#[unimock(api=WithAssocTypeMock)]
trait WithAssocType {
    type X;

    fn exec(&self) -> Option<Self::X>;
}

...

impl<X> WithAssocType for ::unimock::Unimock<::unimock::AssocType<X>> {
    type X = X;

    ...
}

// Unimock<AssocType<X, AssocType<Y, AssocType<Z>>>> and so on for more associated types
```

This will allow `Unimock` to be generic over _any_ number of types with only one generic parameter!

Then, for structs generated for each mockable function from trait, they will
have ordinary generics. To exempt users from need to instantiate those structs,
we can use [`#[ghost::phantom]`][phantom] macro that turns
structs to `PhantomData`-like types, that don't need any data to create instance
to.

This brings us to this interface:

```rust
#[unimock(api=NoArgMock)]
trait NoArg {
    type X;

    fn no_arg(&self) -> Self::X;
}

assert_eq!(
    1_000_000,
    Unimock::with_assoc(
        NoArgMock::no_arg::<i32> // this looks like magic!
            .next_call(matching!())
            .returns(1_000_000)
    )
    .no_arg()
);
```

So, associated types solved? No, not that fast...

# Drawbacks

Unfortunately, it didn't come without drawbacks.

First and obvious one: `Unimock` will have to be parameterized with a generic,
sadly. I hope it's not a big problem, but a breaking change nonetheless.

Second, we'll need two constructor functions on `Unimock`: one for `NoAssocType`
instantiation (`impl Unimock<NoAssocType> { fn new() ... }`) and another one --
for HList instantiation (`impl<Assoc> Unimock<Assoc> { fn with_assoc() ... }`),
unless we are OK with users having to use turbofish every time creating a new
`Unimock`.

Next is that only one `Unimock` would be useful for one trait mock, unless two
traits can share the same _type_ for _associated type_. Like a `Err` type that
is common across entire crate, or similar. In my experience, this is often the
case and therefore is not a problem.

Now for a more obscure one. Due to
[dtolnay/ghost#1](https://github.com/dtolnay/ghost/issues/1), `#[unimock]`
with`unmock` or without `api=` (hidden) is not possible. (Here's simplified
expansion of [`#[ghost::phantom]`][phantom] macro: [playground])

# [My] [unresolved] questions

What do you think about this implementation? Can it be improved/reworked, if it
is not good? I'm asking for a _pre_-review.

This PR is in `Draft` state: I'm working on polishing the code and fixing some
bugs.

It is mostly working though, look at what it can do!

```rust
#[unimock(api=CrazyTraitMock)]
#[async_trait(?Send)]
trait CrazyTrait<'x, T: Default, Unit = ()>
where
    T: ?Sized,
{
    type Ok: Into<Self::Err>;
    type Err: std::fmt::Display + 'static;
    async fn thing2(&'x self, other: Unit, arg: &T) -> Result<Self::Ok, Self::Err>;
}

#[tokio::test]
async fn even_crazier() {
    let u = Unimock::with_assoc(
        CrazyTraitMock::thing2::<&str, String>
            .with_types::<u32, ()>()
            .next_call(matching!((_, 666_666)))
            .returns(Ok("42")),
    );
    assert_eq!(Ok::<_, String>("42"), u.thing2((), &666_666u32).await);
}
```

# Alternatives

I am unfortunately unable to come up with any, but there might be other
(better?) ways to introduce associated types mocking with `unimock`.

About the bug with [`#[ghost::phantom]`][phantom] macro: we could create our own expansion somehow
that does not need that trick with `enum`'s variant imports, though I'm unsure.

# My overall experience with `unimock` implementing this PR

`util::Generics` -- not a fan 😎

[phantom]: https://github.com/dtolnay/ghost
[playground]: https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=1fe7f5af076de91f91cc423f4c15b741
