### PR TITLE
feat: Support self: Pin<&mut Self>

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ unimock_macros = { path = "unimock_macros", version = "0.5.4" }
 once_cell = "1.17"
 pretty_assertions = { version = "1.3", optional = true }
 spin = { version = "0.9.8", optional = true }
+polonius-the-crab = "0.3"
 
 [dev-dependencies]
 async-trait = "0.1"

--- a/src/default_impl_delegator.rs
+++ b/src/default_impl_delegator.rs
@@ -1,0 +1,114 @@
+use core::pin::Pin;
+
+use crate::private::lib::{Arc, Rc};
+use crate::{private, Unimock};
+
+/// The DefaultImplDelegator is a struct
+/// used for implementing only non-default methods of traits.
+///
+/// It is used as part of the infrastructure for supporting default implementation fallbacks in Unimock.
+#[derive(Clone)]
+pub struct DefaultImplDelegator {
+    pub(crate) unimock: Unimock,
+}
+
+impl DefaultImplDelegator {
+    /// Construct a default impl delegator from a unimock instance.
+    ///
+    /// This method exists as a helper in case of type inference problems with `From<T>`.
+    pub fn __from_unimock(unimock: Unimock) -> Self {
+        Self { unimock }
+    }
+}
+
+impl AsRef<Unimock> for DefaultImplDelegator {
+    fn as_ref(&self) -> &Unimock {
+        &self.unimock
+    }
+}
+
+impl AsMut<Unimock> for DefaultImplDelegator {
+    fn as_mut(&mut self) -> &mut Unimock {
+        &mut self.unimock
+    }
+}
+
+#[cfg(feature = "mock-core")]
+impl core::fmt::Display for DefaultImplDelegator {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        <Unimock as core::fmt::Display>::fmt(&self.unimock, f)
+    }
+}
+
+#[cfg(feature = "mock-core")]
+impl core::fmt::Debug for DefaultImplDelegator {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        <Unimock as core::fmt::Debug>::fmt(&self.unimock, f)
+    }
+}
+
+pub trait DelegateToDefaultImpl {
+    type Delegator;
+
+    fn to_delegator(self) -> Self::Delegator;
+
+    fn from_delegator(delegator: Self::Delegator) -> Self;
+}
+
+impl DelegateToDefaultImpl for Unimock {
+    type Delegator = DefaultImplDelegator;
+
+    fn to_delegator(self) -> Self::Delegator {
+        DefaultImplDelegator::__from_unimock(self)
+    }
+
+    fn from_delegator(delegator: Self::Delegator) -> Self {
+        delegator.unimock
+    }
+}
+
+impl DelegateToDefaultImpl for Rc<Unimock> {
+    type Delegator = Rc<DefaultImplDelegator>;
+
+    fn to_delegator(self) -> Self::Delegator {
+        Rc::new(DefaultImplDelegator::__from_unimock((*self).clone()))
+    }
+
+    fn from_delegator(delegator: Self::Delegator) -> Self {
+        Rc::new(delegator.unimock.clone())
+    }
+}
+
+impl DelegateToDefaultImpl for Arc<Unimock> {
+    type Delegator = Arc<DefaultImplDelegator>;
+
+    fn to_delegator(self) -> Self::Delegator {
+        Arc::new(DefaultImplDelegator::__from_unimock((*self).clone()))
+    }
+
+    fn from_delegator(delegator: Self::Delegator) -> Self {
+        Arc::new(delegator.unimock.clone())
+    }
+}
+
+impl<'u> DelegateToDefaultImpl for Pin<&'u mut Unimock> {
+    type Delegator = Pin<&'u mut DefaultImplDelegator>;
+
+    fn to_delegator(self) -> Self::Delegator {
+        let unimock = self.get_mut();
+        let unimock_clone = unimock.clone();
+
+        unimock.default_impl_delegator_cell.get_or_init(|| {
+            private::lib::Box::new(DefaultImplDelegator::__from_unimock(unimock_clone))
+        });
+
+        let delegator = unimock.default_impl_delegator_cell.get_mut().unwrap();
+
+        Pin::new(delegator)
+    }
+
+    fn from_delegator(delegator: Self::Delegator) -> Self {
+        let delegator = delegator.get_mut();
+        Pin::new(&mut delegator.unimock)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -436,6 +436,16 @@ pub mod private;
 #[doc(hidden)]
 pub mod value_chain;
 
+#[doc(hidden)]
+pub mod polonius {
+    pub use polonius_the_crab::exit_polonius as _exit;
+    pub use polonius_the_crab::polonius as _polonius;
+    pub use polonius_the_crab::polonius_return as _return;
+}
+
+#[doc(hidden)]
+mod default_impl_delegator;
+
 mod assemble;
 mod call_pattern;
 mod cell;
@@ -899,12 +909,6 @@ impl AsMut<DefaultImplDelegator> for Unimock {
             private::lib::Box::new(DefaultImplDelegator::__from_unimock(self.clone()))
         });
         self.default_impl_delegator_cell.get_mut().unwrap()
-    }
-}
-
-impl From<DefaultImplDelegator> for Unimock {
-    fn from(value: DefaultImplDelegator) -> Self {
-        value.unimock
     }
 }
 

--- a/src/private.rs
+++ b/src/private.rs
@@ -6,6 +6,8 @@ use crate::{call_pattern::MatchingFn, *};
 
 use lib::{Box, String, Vec};
 
+pub use crate::default_impl_delegator::*;
+
 /// The evaluation of a [MockFn].
 ///
 /// Used to tell trait implementations whether to do perform their own evaluation of a call.
@@ -175,62 +177,6 @@ where
     unimock.handle_error(eval::eval(unimock, inputs, mutation))
 }
 
-/// The DefaultImplDelegator is a struct
-/// used for implementing only non-default methods of traits.
-///
-/// It is used as part of the infrastructure for supporting default implementation fallbacks in Unimock.
-pub struct DefaultImplDelegator {
-    pub(crate) unimock: Unimock,
-}
-
-impl DefaultImplDelegator {
-    /// Construct a default impl delegator from a unimock instance.
-    ///
-    /// This method exists as a helper in case of type inference problems with `From<T>`.
-    pub fn __from_unimock(unimock: Unimock) -> Self {
-        Self { unimock }
-    }
-
-    /// Construct a default impl delegator from a unimock instance.
-    ///
-    /// This method exists as a helper in case of type inference problems with `From<T>`.
-    pub fn __cast_unimock_default_impl_delegator<T: From<Self>>(self) -> T {
-        self.into()
-    }
-}
-
-impl From<Unimock> for DefaultImplDelegator {
-    fn from(unimock: Unimock) -> Self {
-        Self { unimock }
-    }
-}
-
-impl AsRef<Unimock> for DefaultImplDelegator {
-    fn as_ref(&self) -> &Unimock {
-        &self.unimock
-    }
-}
-
-impl AsMut<Unimock> for DefaultImplDelegator {
-    fn as_mut(&mut self) -> &mut Unimock {
-        &mut self.unimock
-    }
-}
-
-#[cfg(feature = "mock-core")]
-impl core::fmt::Display for DefaultImplDelegator {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        <Unimock as core::fmt::Display>::fmt(&self.unimock, f)
-    }
-}
-
-#[cfg(feature = "mock-core")]
-impl core::fmt::Debug for DefaultImplDelegator {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        <Unimock as core::fmt::Debug>::fmt(&self.unimock, f)
-    }
-}
-
 /// Clone a Unimock instance
 pub fn clone_unimock(unimock: &Unimock) -> Unimock {
     unimock.clone()
@@ -307,6 +253,7 @@ pub mod lib {
     pub use ::std::collections::BTreeMap;
     pub use ::std::collections::BTreeSet;
     pub use ::std::format;
+    pub use ::std::rc::Rc;
     pub use ::std::string::String;
     pub use ::std::string::ToString;
     pub use ::std::sync::Arc;
@@ -322,6 +269,7 @@ pub mod lib {
     pub use ::alloc::collections::BTreeMap;
     pub use ::alloc::collections::BTreeSet;
     pub use ::alloc::format;
+    pub use ::alloc::rc::Rc;
     pub use ::alloc::string::String;
     pub use ::alloc::string::ToString;
     pub use ::alloc::sync::Arc;

--- a/tests/it/default_impl.rs
+++ b/tests/it/default_impl.rs
@@ -175,3 +175,40 @@ mod default_impl_async_trait {
         }
     }
 }
+
+mod default_impl_pin {
+    use core::pin::Pin;
+
+    use unimock::*;
+
+    #[unimock(api = PinDefault1Mock)]
+    trait PinDefault1 {
+        fn pinned(self: Pin<&mut Self>, arg: i32) -> &i32;
+
+        fn pinned_default(self: Pin<&mut Self>) -> &i32 {
+            self.pinned(123)
+        }
+    }
+
+    #[unimock(api = PinDefault2Mock)]
+    trait PinDefault2 {
+        fn pinned(self: Pin<&mut Self>, arg: i32) -> &i32;
+
+        fn pinned_default(self: Pin<&mut Self>) -> &i32 {
+            self.pinned(123)
+        }
+    }
+
+    #[test]
+    fn mock_pin_default() {
+        let mut unimock = Unimock::new(
+            PinDefault1Mock::pinned
+                .next_call(matching!(123))
+                .answers(|_| 666),
+        );
+        assert_eq!(
+            &666,
+            <Unimock as PinDefault1>::pinned_default(Pin::new(&mut unimock))
+        );
+    }
+}


### PR DESCRIPTION
On the way to supporting `AsyncRead|Write` mocks, unimock needs to support `self: Pin<&mut Self>`.

The interaction between this type and the _default impl delegator_ triggered a borrowing pattern that requires [polonius](https://github.com/rust-lang/polonius).

The pattern is something like this:

```
fn func(self: Pin<&mut Self>) {
    let __self: &mut Self = ::core::pin::Pin::into_inner(self);
    match eval::<MockFn>(__self) { // returns an `Evaluation` with a borrow of __self
        CallDefaultImpl(_args) => {
            // The Evaluation is not used anymore after the _args are extracted.
            let re_pinned = ::core::pin::Pin::new(__self);
            // ^----- this is not possible without polonius. The borrow within `__self` lasts until the end of the function 
            DefaultImplDelegator::func(re_pinned);
        }
        evaluated => evaluated.unwrap(__self)
    }
}
```

The solution to this is to use [polonius-the-crab](https://crates.io/crates/polonius-the-crab/) (hilarious!), re-export parts of it and make a special case only for Pin where this is used.