### PR TITLE
feat: Add no_std support

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Test std
         run: cargo hack --feature-powerset --features std --exclude-features default,spin-lock,nightly-tests,unstable-doc-cfg test
       - name: Test no_std
-        run: cargo hack --feature-powerset --exclude-features std,mock-std,default,nightly-tests,unstable-doc-cfg test
+        run: cargo hack --feature-powerset --features critical-section --exclude-features std,mock-std,default,nightly-tests,unstable-doc-cfg test
       - name: Doctest
         run: cargo test --doc --features mock-core,mock-std
       - name: Clippy

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,22 +15,24 @@ categories = ["development-tools", "development-tools::testing", "no-std"]
 [features]
 default = ["std", "pretty-print"]
 pretty-print = ["dep:pretty_assertions"]
-std = []
+std = ["once_cell/std"]
 spin-lock = ["dep:spin"]
 mock-core = []
 mock-std = ["std", "mock-core"]
 nightly-tests = []
 unstable-doc-cfg = []
+critical-section = ["once_cell/critical-section"]
 
 [dependencies]
 unimock_macros = { path = "unimock_macros", version = "0.5.5" }
-once_cell = "1.17"
+once_cell = { version = "1.17", default-features = false }
 polonius-the-crab = "0.3"
 pretty_assertions = { version = "1.3", optional = true }
 spin = { version = "0.9.8", optional = true }
 
 [dev-dependencies]
 async-trait = "0.1"
+critical-section = { version = "1.1.2", features = ["std"] }
 tokio = { version = "1", features = ["full"] }
 
 [lib]


### PR DESCRIPTION
Right now, in a no_std project I am working on I cannot use unimock as the once_cell crate uses std by default and needs to be disabled by using `default-features = false`. The `critical-section` feature in once_cell can be used in a no_std project to enable sync features so I added that as a feature to this crate too.

I tried the current version of unimock in a no_std project and it doesn't work but with this change it does work.

Thanks for your effort on this library :+1: 