### PR TITLE
Add support for associated constants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- (static) Associated constants support with `#[unimock(const FOO: Type = value;)]`.
 
 ## [0.5.6] - 2023-11-15
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -310,7 +310,7 @@ These mock APIs can be found in [mock].
 #### What kinds of things can be mocked with unimock?
 * Traits with any number of methods
 * Traits with generic parameters, although these cannot be lifetime constrained (i.e. need to satisfy `T: 'static`).
-* Traits with associated types, using `#[unimock(type T = Foo;)]` syntax.
+* Traits with associated types and constants, using `#[unimock(type T = Foo; const FOO: T = value;)]` syntax.
 * Methods with any self receiver (`self`, `&self`, `&mut self` or arbitrary (e.g. `self: Rc<Self>`)).
 * Methods that take reference inputs.
 * Methods returning references to self.
@@ -359,6 +359,19 @@ trait Trait {
 
 Working with associated types in a mock environment like Unimock has its limitations.
 The nature of associated types is that there is one type per implementation, and there is only one mock implementation, so the type must be chosen carefully.
+
+#### Associated constants
+Associated constants in traits may be specified using the `const` keyword in the unimock macro:
+
+```rust
+#[unimock(api = TraitMock, const FOO: i32 = 42;)]
+trait Trait {
+    const FOO: i32;
+}
+```
+
+Just like with associated types in Unimock, associated constants have the limitation where there is one value of the const per implementation,
+and there is only one mock implementation, so the value must be chosen carefully.
 
 
 ## Project goals

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -330,7 +330,7 @@
 //! #### What kinds of things can be mocked with unimock?
 //! * Traits with any number of methods
 //! * Traits with generic parameters, although these cannot be lifetime constrained (i.e. need to satisfy `T: 'static`).
-//! * Traits with associated types, using `#[unimock(type T = Foo;)]` syntax.
+//! * Traits with associated types and constants, using `#[unimock(type T = Foo; const FOO: T = value;)]` syntax.
 //! * Methods with any self receiver (`self`, `&self`, `&mut self` or arbitrary (e.g. `self: Rc<Self>`)).
 //! * Methods that take reference inputs.
 //! * Methods returning references to self.
@@ -380,6 +380,20 @@
 //!
 //! Working with associated types in a mock environment like Unimock has its limitations.
 //! The nature of associated types is that there is one type per implementation, and there is only one mock implementation, so the type must be chosen carefully.
+//!
+//! #### Associated constants
+//! Associated constants in traits may be specified using the `const` keyword in the unimock macro:
+//!
+//! ```rust
+//! # use unimock::*;
+//! #[unimock(api = TraitMock, const FOO: i32 = 42;)]
+//! trait Trait {
+//!     const FOO: i32;
+//! }
+//! ```
+//!
+//! Just like with associated types in Unimock, associated constants have the limitation where there is one value of the const per implementation,
+//! and there is only one mock implementation, so the value must be chosen carefully.
 //!
 //!
 //! ## Project goals

--- a/tests/it/basic.rs
+++ b/tests/it/basic.rs
@@ -993,6 +993,34 @@ mod associated_type {
     }
 }
 
+mod associated_const {
+    use unimock::*;
+
+    #[unimock(api = AssocConstMock, const FOO: i32 = 42;)]
+    pub trait Assoc {
+        const FOO: i32;
+    }
+}
+
+mod associated_type_and_const {
+    use unimock::*;
+
+    #[unimock(api = AssocMock, type Foo = i32; const FOO: &'static str = "it works!"; type Bar = i32; const BAR: bool = true;)]
+    pub trait Assoc {
+        type Foo;
+        type Bar;
+
+        const FOO: &'static str;
+        const BAR: bool;
+
+        fn assoc_ret(&self) -> Self::Foo;
+        fn assoc_ref_ret(&self) -> &Self::Foo;
+        fn assoc_mixed_ret(&self) -> Option<&Self::Foo>;
+        fn assoc_arg(&self, arg: Self::Foo) -> bool;
+        fn assoc_ref_arg(&self, arg: &Self::Foo) -> bool;
+    }
+}
+
 mod no_verify_in_drop {
     use unimock::*;
 

--- a/unimock_macros/src/unimock/attr.rs
+++ b/unimock_macros/src/unimock/attr.rs
@@ -9,6 +9,7 @@ pub struct Attr {
     /// Module to put the MockFn in
     pub mock_api: MockApi,
     pub associated_types: HashMap<String, syn::TraitItemType>,
+    pub associated_consts: HashMap<String, syn::TraitItemConst>,
     unmocks: Option<WithSpan<Vec<Unmock>>>,
     pub mirror: Option<syn::Path>,
     pub input_lifetime: syn::Lifetime,
@@ -48,6 +49,7 @@ impl syn::parse::Parse for Attr {
         let mut prefix: Option<syn::Path> = None;
         let mut mock_api = MockApi::Hidden;
         let mut associated_types = HashMap::default();
+        let mut associated_consts = HashMap::default();
         let mut unmocks = None;
         let mut debug = false;
         let mut mirror = None;
@@ -57,6 +59,10 @@ impl syn::parse::Parse for Attr {
                 let trait_item_type: syn::TraitItemType = input.parse()?;
 
                 associated_types.insert(trait_item_type.ident.to_string(), trait_item_type);
+            } else if input.peek(syn::token::Const) {
+                let trait_item_const: syn::TraitItemConst = input.parse()?;
+
+                associated_consts.insert(trait_item_const.ident.to_string(), trait_item_const);
             } else {
                 let keyword: syn::Ident = input.parse()?;
                 match keyword.to_string().as_str() {
@@ -120,6 +126,7 @@ impl syn::parse::Parse for Attr {
             prefix: prefix.unwrap_or_else(|| syn::parse_quote! { ::unimock }),
             mock_api,
             associated_types,
+            associated_consts,
             unmocks,
             mirror,
             input_lifetime: syn::Lifetime::new("'__i", proc_macro2::Span::call_site()),


### PR DESCRIPTION
Thanks again for the quick review and merge yesterday!
Based on that, I thought I'd look into adding support for associated constants, which is the purpose of this PR.

I copied the implementation of the associated types, I think it is possible to combine some of the logic so that it's not checking for `type ...` and then for `const ...` with very similar logic. For now, though, I wanted to get something working and see what you think of it.

Thanks.