### PR TITLE
feat: Apply fn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Changed
+- Unimock now supports very flexible argument mutation, instead of one hard-coded parameter.
+  A new `applies()` function-responder has been added, in favor of the old `answers()`, `answers_leaked_ref()`, `mutates()`.
+  The function passed to `applies()` API can mutate all its inputs freely.
+  The downside to this new mechanism is that its return type can't be generic (i.e. `Ret: IntoResponse`).
+  Flexible return types are still supported though, but now a response has to be created explicitly calling `unimock::respond(return_value)`.
 ### Fixed
 - Fix `matching!` against references to number literals ([#42](https://github.com/audunhalland/unimock/pull/42))
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -49,6 +49,9 @@ pub(crate) enum MockError {
     NoDefaultImpl {
         info: MockFnInfo,
     },
+    NotApplied {
+        info: MockFnInfo,
+    },
     ExplicitPanic {
         fn_call: debug::FnActualCall,
         pattern: debug::CallPatternDebug,
@@ -124,6 +127,13 @@ impl core::fmt::Display for MockError {
                 write!(
                     f,
                     "{path} has not been set up with default implementation delegation.",
+                    path = info.path
+                )
+            }
+            Self::NotApplied { info } => {
+                write!(
+                    f,
+                    "{path} did not apply the function, this is a bug.",
                     path = info.path
                 )
             }

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -27,7 +27,6 @@ struct EvalResponder<'u> {
 pub(crate) fn eval<'u, 'i, F: MockFn>(
     unimock: &'u Unimock,
     inputs: F::Inputs<'i>,
-    _mutation: &mut F::Mutation<'_>,
 ) -> MockResult<Evaluation<'u, 'i, F>> {
     let dyn_ctx = DynCtx {
         info: F::info(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -961,7 +961,7 @@ impl Drop for Unimock {
 impl std::process::Termination for Unimock {
     #[cfg(feature = "mock-std")]
     fn report(mut self) -> std::process::ExitCode {
-        match private::eval::<mock::std::process::TerminationMock::report>(&self, (), &mut ()) {
+        match private::eval::<mock::std::process::TerminationMock::report>(&self, ()) {
             private::Evaluation::Unmocked(_) => teardown::teardown_report(&mut self),
             e => e.unwrap(&self),
         }
@@ -1006,14 +1006,6 @@ pub trait MockFn: Sized + 'static {
     /// * For a function with 1 parameter `T`, the type should be `T`.
     /// * For a function with N parameters, the type should be the tuple `(T1, T2, ..)`.
     type Inputs<'i>;
-
-    /// A mutable parameter.
-    ///
-    /// Some methods are designed around a `&mut T` parameter, where the trait is supposed to
-    /// perform some mutable operation on this parameter. Unimock currently supports 1 such parameter.
-    ///
-    /// For methods without any mutable parameters, this type should be `()`.
-    type Mutation<'m>: ?Sized;
 
     /// A type that describes how the mocked function responds.
     ///
@@ -1152,25 +1144,8 @@ impl MockFnInfo {
     }
 }
 
-/// A type that indicates a mutated argument.
-///
-/// Unimock inputs cannot be mutated directly.
-/// To interact with a mutable reference argument, use [crate::build::DefineResponse::mutates].
-pub struct PhantomMut<T>(core::marker::PhantomData<T>);
-
-impl<T> Default for PhantomMut<T> {
-    fn default() -> Self {
-        Self(core::marker::PhantomData)
-    }
-}
-
-impl<T> Debug for PhantomMut<T> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        write!(f, "PhantomMut")
-    }
-}
-
 /// A marker type used when Unimock is unable to represent the user's type.
+#[derive(Debug)]
 pub struct Impossible;
 
 /// A clause represents a recipe for creating a unimock instance.

--- a/src/mock/std.rs
+++ b/src/mock/std.rs
@@ -86,7 +86,6 @@ pub mod process {
 
         impl MockFn for report {
             type Inputs<'i> = ();
-            type Mutation<'m> = ();
             type Response = Owned<std::process::ExitCode>;
             type Output<'u> = Self::Response;
             type ApplyFn = dyn Fn() -> Response<Self> + Send + Sync;

--- a/src/mock/std.rs
+++ b/src/mock/std.rs
@@ -75,7 +75,7 @@ pub mod process {
     /// Unimock mock API for [std::process::Termination].
     #[allow(non_snake_case)]
     pub mod TerminationMock {
-        use crate::{output::Owned, MockFn};
+        use crate::{output::Owned, MockFn, Response};
 
         #[allow(non_camel_case_types)]
         /// MockFn for [`Termination::report() -> ExitCode`](std::process::Termination::report).
@@ -89,6 +89,7 @@ pub mod process {
             type Mutation<'m> = ();
             type Response = Owned<std::process::ExitCode>;
             type Output<'u> = Self::Response;
+            type ApplyFn = dyn Fn() -> Response<Self> + Send + Sync;
 
             fn info() -> crate::MockFnInfo {
                 let mut info = crate::MockFnInfo::new::<Self>().path("Termination", "report");

--- a/src/private.rs
+++ b/src/private.rs
@@ -1,3 +1,5 @@
+use core::ops::Deref;
+
 use crate::call_pattern::InputIndex;
 use crate::debug;
 use crate::mismatch::{Mismatch, MismatchKind};
@@ -17,6 +19,8 @@ pub use crate::default_impl_delegator::*;
 pub enum Evaluation<'u, 'i, F: MockFn> {
     /// Function evaluated to its output.
     Evaluated(<F::Output<'u> as Output<'u, F::Response>>::Type),
+    /// Function should be applied
+    Apply(ApplyClosure<'u, F>, F::Inputs<'i>),
     /// Function not yet evaluated, should be unmocked.
     Unmocked(F::Inputs<'i>),
     /// Function not yet evaluated, should call default implementation.
@@ -30,11 +34,42 @@ impl<'u, 'i, F: MockFn> Evaluation<'u, 'i, F> {
     pub fn unwrap(self, unimock: &Unimock) -> <F::Output<'u> as Output<'u, F::Response>>::Type {
         let error = match self {
             Self::Evaluated(output) => return output,
+            Self::Apply(..) => error::MockError::NotApplied { info: F::info() },
             Self::Unmocked(_) => error::MockError::CannotUnmock { info: F::info() },
             Self::CallDefaultImpl(_) => error::MockError::NoDefaultImpl { info: F::info() },
         };
 
         unimock.induce_panic(error)
+    }
+}
+
+#[doc(hidden)]
+pub struct ApplyClosure<'u, F: MockFn> {
+    pub(crate) unimock: &'u Unimock,
+    pub(crate) apply_fn: &'u F::ApplyFn,
+}
+
+impl<'u, F: MockFn> Deref for ApplyClosure<'u, F> {
+    type Target = F::ApplyFn;
+
+    fn deref(&self) -> &Self::Target {
+        self.apply_fn
+    }
+}
+
+impl<'u, F: MockFn> ApplyClosure<'u, F> {
+    pub fn __to_output(
+        &self,
+        response: Response<F>,
+    ) -> <F::Output<'u> as Output<'u, F::Response>>::Type {
+        let response = match response.0 {
+            ResponseInner::Response(response) => response,
+            ResponseInner::Unimock(func) => func(self.unimock.clone()),
+        };
+        <F::Output<'u> as output::Output<'u, <F as MockFn>::Response>>::from_response(
+            response,
+            &self.unimock.value_chain,
+        )
     }
 }
 

--- a/src/private.rs
+++ b/src/private.rs
@@ -201,15 +201,11 @@ impl MismatchReporter {
 
 /// Evaluate a [MockFn] given some inputs, to produce its output.
 #[track_caller]
-pub fn eval<'u, 'i, F>(
-    unimock: &'u Unimock,
-    inputs: F::Inputs<'i>,
-    mutation: &mut F::Mutation<'_>,
-) -> Evaluation<'u, 'i, F>
+pub fn eval<'u, 'i, F>(unimock: &'u Unimock, inputs: F::Inputs<'i>) -> Evaluation<'u, 'i, F>
 where
     F: MockFn + 'static,
 {
-    unimock.handle_error(eval::eval(unimock, inputs, mutation))
+    unimock.handle_error(eval::eval(unimock, inputs))
 }
 
 /// Clone a Unimock instance

--- a/tests/it/default_impl.rs
+++ b/tests/it/default_impl.rs
@@ -30,7 +30,7 @@ mod default_impl_borrowed {
             Unimock::new(
                 DefaultBodyMock::default_body
                     .next_call(matching!(21))
-                    .answers(|_| 777)
+                    .applies(&|_| respond(777))
             )
             .default_body(21)
         );
@@ -43,7 +43,7 @@ mod default_impl_borrowed {
             Unimock::new(
                 DefaultBodyMock::core
                     .next_call(matching!(42))
-                    .answers(|_| 666)
+                    .applies(&|_| respond(666))
             )
             .default_body(21)
         );
@@ -69,7 +69,7 @@ mod default_impl_mut {
             Unimock::new(
                 MutDefaultBodyMock::default_body
                     .next_call(matching!(21))
-                    .answers(|_| 777)
+                    .applies(&|_arg| respond(777))
             )
             .default_body(21)
         );
@@ -82,7 +82,7 @@ mod default_impl_mut {
             Unimock::new(
                 MutDefaultBodyMock::core
                     .next_call(matching!(42))
-                    .answers(|_| 666)
+                    .applies(&|_| respond(666))
             )
             .default_body(21)
         );
@@ -105,7 +105,7 @@ mod default_impl_mut {
             Unimock::new(
                 MutDefaultBodyBorrowMock::borrow_ret
                     .next_call(matching!(42))
-                    .answers(|_| 666)
+                    .applies(&|_| respond(666))
             )
             .default_borrow_ret(21)
         );
@@ -133,7 +133,7 @@ mod default_impl_rc {
             Rc::new(Unimock::new(
                 DefaultBodyMock::default_body
                     .next_call(matching!(21))
-                    .answers(|_| 777)
+                    .applies(&|_| respond(777))
             ))
             .default_body(21)
         );
@@ -161,7 +161,7 @@ mod default_impl_arc {
             Arc::new(Unimock::new(
                 DefaultBodyMock::default_body
                     .next_call(matching!(21))
-                    .answers(|_| 777)
+                    .applies(&|_| respond(777))
             ))
             .default_body(21)
         );
@@ -256,7 +256,7 @@ mod default_impl_pin {
         let mut unimock = Unimock::new(
             PinDefault1Mock::pinned
                 .next_call(matching!(123))
-                .answers(|_| 666),
+                .applies(&|_| respond(666)),
         );
         assert_eq!(
             &666,

--- a/tests/it/generic.rs
+++ b/tests/it/generic.rs
@@ -334,8 +334,9 @@ mod issue_37_mutation_with_generics {
         MockMock::func
             .with_types::<()>()
             .next_call(matching!())
-            .mutates(|foo, _| {
+            .applies(&|_, foo| {
                 foo.baz += 1;
+                respond(())
             });
     }
 }

--- a/tests/it/mixed.rs
+++ b/tests/it/mixed.rs
@@ -180,7 +180,7 @@ fn mixed_tuple_clone_combinatorics_many() {
     let u = Unimock::new(
         MixedTupleMock::tuple4
             .each_call(matching!())
-            .answers(|_| (clone::Nope, clone::Nope, clone::Sure, clone::Sure)),
+            .applies(&|| respond((clone::Nope, clone::Nope, clone::Sure, clone::Sure))),
     );
 
     for _ in 0..3 {

--- a/tests/it/std.rs
+++ b/tests/it/std.rs
@@ -16,8 +16,8 @@ fn test_display() {
         "u",
         Unimock::new(
             DisplayMock::fmt
-                .next_call(matching!())
-                .mutates(|f, _| write!(f, "u"))
+                .next_call(matching!(_))
+                .applies(&|f| respond(write!(f, "u")))
         )
         .to_string()
     );
@@ -39,7 +39,7 @@ fn test_debug() {
     let unimock = Unimock::new(
         DebugMock::fmt
             .next_call(matching!())
-            .mutates(|f, _| write!(f, "u")),
+            .applies(&|f| respond(write!(f, "u"))),
     );
 
     assert_eq!("u", format!("{unimock:?}"));
@@ -50,10 +50,10 @@ fn test_read() {
     let mut reader = BufReader::new(Unimock::new((
         ReadMock::read
             .next_call(matching!(_))
-            .mutates(|mut f, _| f.write(b"ok")),
+            .applies(&|mut f| respond(f.write(b"ok"))),
         ReadMock::read
             .next_call(matching!(_))
-            .mutates(|mut f, _| f.write(b"\n")),
+            .applies(&|mut f| respond(f.write(b"\n"))),
     )));
 
     let mut line = String::new();
@@ -95,7 +95,7 @@ fn test_fmt_io_duplex_default_impl_implicit() {
     let unimock = Unimock::new((
         DisplayMock::fmt
             .next_call(matching!())
-            .mutates(|f, _| write!(f, "hello {}", "unimock".to_string())),
+            .applies(&|f| respond(write!(f, "hello {}", "unimock".to_string()))),
         // NOTE: write! calls `write_all` which should get re-routed to `write`:
         WriteMock::write
             .next_call(matching!(eq!(b"hello ")))
@@ -115,7 +115,7 @@ fn test_fmt_io_duplex_default_impl_explicit() {
     let unimock = Unimock::new((
         DisplayMock::fmt
             .next_call(matching!())
-            .mutates(|f, _| write!(f, "hello {}", "unimock".to_string())),
+            .applies(&|f| respond(write!(f, "hello {}", "unimock".to_string()))),
         WriteMock::write_all
             .next_call(matching!(eq!(b"hello ")))
             .default_implementation(),

--- a/unimock_macros/src/unimock/method.rs
+++ b/unimock_macros/src/unimock/method.rs
@@ -337,7 +337,7 @@ pub fn extract_methods<'s>(
                                 ident: pat_ident.ident.clone(),
                                 ty: util::substitute_lifetimes(
                                     type_ref.elem.as_ref().clone(),
-                                    &syn::parse_quote!('m),
+                                    Some(&syn::parse_quote!('m)),
                                 ),
                             })
                         }


### PR DESCRIPTION
A new API for evaluating the mocked response via user-supplied function. The new API replaces `answers` and `mutates`-family of APIs, as the new API unifies everything.

This is implemented by adding the new associated type `type ApplyFn` to `MockFn`. In the trait implementations it will be instantiated to some `dyn Fn(..arguments) -> Response<Self>`. This is AFAIK the only way to retain full flexibility regarding variance (i.e. lifetimes) on its parameters; it will perfectly mirror the signature of the mocked trait function.

Unfortunately a `dyn Fn` can't have a generic return type (as the old APIs had) so this change forces some verbosity onto the user, though I think I've found a good enough solution: Each "apply fn" has to return a `Response<F>`, a struct that is instantiated be using `unimock::respond(value)`, and _that_ function takes a generic parameter. So now every function application will look like this:

```
my_mock
    .next_call(matching!())
    .applies(&|args| respond(1337))
```

Also note that a _reference_ to the function must be passed in (this is the nature of `dyn Fn`, I was unable to define a trait for function conversion without running into variance problems). This means that the standard API does not support closures, but a "static function". To use a closure, one can use the alternative API:

```
my_mock
    .next_call(matching!())
    .applies_closure(Box::new(move |args| {
        // can use upvars here
        respond(1337)
    })
```

fixes #40 