### PR TITLE
feat: Bring back AnswerFn with support for parameter borrows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,16 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 ### Changed
 - Unimock now supports very flexible argument mutation, instead of one hard-coded parameter.
-  A new `applies()` function-responder has been added, in favor of the old `answers()`, `answers_leaked_ref()`, `mutates()`.
-  The function passed to `applies()` API can mutate all its inputs freely.
-  The downside to this new mechanism is that its return type can't be generic (i.e. `Ret: IntoResponse`).
-  Flexible return types are still supported though, but now a response has to be created explicitly calling `unimock::respond(return_value)`. ([#43](https://github.com/audunhalland/unimock/pull/43))
+  To achieve this, the `answers` API had to be redesigned with a new signature based on a `dyn Fn`.
+  This dynamic function type has one fixed signature per `MockFn`, so its return type isn't generic as it used to be in `0.5.x`.
+  All generated borrows have to be done explicitly through `Unimock::make_ref` for this to work. ([#43](https://github.com/audunhalland/unimock/pull/43), [#47](https://github.com/audunhalland/unimock/pull/47))
+  - The function passed to `answers` must be a `&static` Fn, _or_ it can be an `Arc` closure that can be registered by calling `answers_arc`.
+  - The parameters passed to this function are the same as passed to the mocked trait method, including `self`.
 - Output trait hierarchy (which allows safely mocking borrowed return values) rewritten to be more flexible and future-proof than previously ([#46](https://github.com/audunhalland/unimock/pull/46))
 - `default_implementation` renamed to `applies_default_impl`.
 ### Added
 - Mocks for `tokio-1` and `futures-0-3` async read/write traits ([#45](https://github.com/audunhalland/unimock/pull/45))
 ### Fixed
 - Fix `matching!` against references to number literals ([#42](https://github.com/audunhalland/unimock/pull/42))
+- Borrows from function arguments can now be made without leaking memory ([#47](https://github.com/audunhalland/unimock/pull/47))
+### Removed
+- The `mutates` builder APIs. These are now handled using `answers`.
 
 ## [0.5.8] - 2024-01-15
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -105,21 +105,17 @@ There are different constraints acting on return values based on how the clause 
 ### Mutating inputs
 Many traits uses the argument mutation pattern, where there are one or more `&mut` parameters.
 
-To access the `&mut` parameters, a function is applied to the call pattern using `applies`:
+To access the `&mut` parameters, a function is applied to the call pattern using `answers`:
 
 ```rust
 let mocked = Unimock::new(
     mock::core::fmt::DisplayMock::fmt
         .next_call(matching!(_))
-        .applies(&|f| respond(write!(f, "mutation!")))
+        .answers(&|_, f| write!(f, "mutation!"))
 );
 
 assert_eq!("mutation!", format!("{mocked}"));
 ```
-
-The applied function also specifies the response, which is constructed by calling [respond].
-In the `fmt` case, the return type is [core::fmt::Result].
-The respond function helps with automatic type conversion and automatic borrowing.
 
 ## Combining setup clauses
 `Unimock::new()` accepts as argument anything that implements [Clause].
@@ -146,10 +142,10 @@ assert_eq!(
         &Unimock::new((
             FooMock::foo
                 .some_call(matching!(_))
-                .applies(&|arg| respond(arg * 3)),
+                .answers(&|_, arg| arg * 3),
             BarMock::bar
                 .some_call(matching!((arg) if *arg > 20))
-                .applies(&|arg| respond(arg * 2)),
+                .answers(&|_, arg| arg * 2),
         )),
         7
     )
@@ -163,10 +159,10 @@ assert_eq!(
         &Unimock::new((
             FooMock::foo.stub(|each| {
                 each.call(matching!(1337)).returns(1024);
-                each.call(matching!(_)).applies(&|arg| respond(arg * 3));
+                each.call(matching!(_)).answers(&|_, arg| arg * 3);
             }),
             BarMock::bar.stub(|each| {
-                each.call(matching!((arg) if *arg > 20)).applies(&|arg| respond(arg * 2));
+                each.call(matching!((arg) if *arg > 20)).answers(&|_, arg| arg * 2);
             }),
         )),
         7

--- a/src/error.rs
+++ b/src/error.rs
@@ -49,7 +49,7 @@ pub(crate) enum MockError {
     NoDefaultImpl {
         info: MockFnInfo,
     },
-    NotApplied {
+    NotAnswered {
         info: MockFnInfo,
     },
     ExplicitPanic {
@@ -130,10 +130,10 @@ impl core::fmt::Display for MockError {
                     path = info.path
                 )
             }
-            Self::NotApplied { info } => {
+            Self::NotAnswered { info } => {
                 write!(
                     f,
-                    "{path} did not apply the function, this is a bug.",
+                    "{path} did not apply the answer function, this is a bug.",
                     path = info.path
                 )
             }

--- a/src/mock/std.rs
+++ b/src/mock/std.rs
@@ -76,7 +76,7 @@ pub mod process {
     /// Unimock mock API for [std::process::Termination].
     #[allow(non_snake_case)]
     pub mod TerminationMock {
-        use crate::{output::Owning, MockFn, Respond};
+        use crate::{output::Owning, MockFn};
         use std::{boxed::Box, string::String};
 
         #[allow(non_camel_case_types)]
@@ -89,7 +89,7 @@ pub mod process {
         impl MockFn for report {
             type Inputs<'i> = ();
             type OutputKind = Owning<std::process::ExitCode>;
-            type ApplyFn = dyn Fn() -> Respond<Self> + Send + Sync;
+            type AnswerFn = dyn Fn() -> Self + Send + Sync;
 
             fn info() -> crate::MockFnInfo {
                 let mut info = crate::MockFnInfo::new::<Self>().path(&["Termination", "report"]);

--- a/src/output.rs
+++ b/src/output.rs
@@ -1,4 +1,6 @@
-use crate::{alloc::Box, value_chain::ValueChain};
+//! Traits for modelling the output of MockFns used with `returns`.
+
+use crate::alloc::Box;
 
 pub(crate) mod deep;
 pub(crate) mod lending;
@@ -19,10 +21,6 @@ type OutputResult<T> = Result<T, OutputError>;
 pub trait Kind: 'static {
     /// A type used to store return values
     type Return: GetOutput;
-
-    /// A type used to hold ephemeral values for [crate::respond]
-    /// These do not require [Send], [Sync] bounds.
-    type Respond: for<'u> IntoOutput<Output<'u> = <Self::Return as GetOutput>::Output<'u>>;
 }
 
 /// A [Kind] that may be used with `returns` combinators.
@@ -43,17 +41,6 @@ pub trait GetOutput: Sized + 'static {
     fn output(&self) -> Option<Self::Output<'_>>;
 }
 
-/// A type that can be converted into an output by consuming it.
-pub trait IntoOutput: Sized + 'static {
-    /// The output this value turns into
-    type Output<'u>
-    where
-        Self: 'u;
-
-    /// Turn this value into an output
-    fn into_output(self, value_chain: &ValueChain) -> Self::Output<'_>;
-}
-
 /// A type that can be converted into a [Kind::Return] that can be returned one time.
 pub trait IntoReturnOnce<K: Kind> {
     #[doc(hidden)]
@@ -70,12 +57,6 @@ pub trait IntoReturn<K: Kind>: IntoReturnOnce<K> {
 pub trait ReturnDefault<K: Kind> {
     #[doc(hidden)]
     fn return_default() -> K::Return;
-}
-
-/// A type that may be converted into a [crate::Respond].
-pub trait IntoRespond<K: Kind> {
-    #[doc(hidden)]
-    fn into_respond(self) -> OutputResult<K::Respond>;
 }
 
 pub use deep::Deep;

--- a/src/output/deep/option.rs
+++ b/src/output/deep/option.rs
@@ -4,7 +4,6 @@ type Mix<K> = Deep<Option<K>>;
 
 impl<K: Kind> Kind for Mix<K> {
     type Return = AsReturn<K>;
-    type Respond = AsRespond<K>;
 }
 
 impl<K> Return for Mix<K>
@@ -39,30 +38,6 @@ where
     }
 }
 
-pub enum AsRespond<K: Kind> {
-    Some(K::Respond),
-    None,
-}
-
-impl<K: Kind> IntoOutput for AsRespond<K>
-where
-    Self: 'static,
-{
-    type Output<'u> =
-        Option<
-            <<K as Kind>::Respond as IntoOutput>::Output<'u>,
-        >
-        where
-            Self: 'u;
-
-    fn into_output(self, value_chain: &ValueChain) -> Self::Output<'_> {
-        match self {
-            Self::Some(val) => Some(val.into_output(value_chain)),
-            Self::None => None,
-        }
-    }
-}
-
 impl<T, K: Return> IntoReturnOnce<Mix<K>> for Option<T>
 where
     <K as Return>::Type: 'static + Send + Sync,
@@ -85,18 +60,6 @@ where
         match self {
             Some(val) => Ok(AsReturn::Some(val.into_return()?)),
             None => Ok(AsReturn::None),
-        }
-    }
-}
-
-impl<T, K: Kind> IntoRespond<Mix<K>> for Option<T>
-where
-    T: IntoRespond<K>,
-{
-    fn into_respond(self) -> OutputResult<AsRespond<K>> {
-        match self {
-            Some(val) => Ok(AsRespond::Some(val.into_respond()?)),
-            None => Ok(AsRespond::None),
         }
     }
 }

--- a/src/output/deep/result.rs
+++ b/src/output/deep/result.rs
@@ -8,7 +8,6 @@ where
     EK: Kind,
 {
     type Return = AsReturn<TK, EK>;
-    type Respond = AsRespond<TK, EK>;
 }
 
 impl<TK, EK> Return for Mix<TK, EK>
@@ -48,33 +47,6 @@ where
     }
 }
 
-pub enum AsRespond<TK: Kind, EK: Kind> {
-    Ok(TK::Respond),
-    Err(EK::Respond),
-}
-
-impl<TK, EK> IntoOutput for AsRespond<TK, EK>
-where
-    TK: Kind,
-    EK: Kind,
-    Self: 'static,
-{
-    type Output<'u> =
-        Result<
-            <<TK as Kind>::Respond as IntoOutput>::Output<'u>,
-            <<EK as Kind>::Respond as IntoOutput>::Output<'u>,
-        >
-        where
-            Self: 'u;
-
-    fn into_output(self, value_chain: &ValueChain) -> Self::Output<'_> {
-        match self {
-            Self::Ok(val) => Ok(val.into_output(value_chain)),
-            Self::Err(val) => Err(val.into_output(value_chain)),
-        }
-    }
-}
-
 impl<T, TK, E, EK> IntoReturnOnce<Mix<TK, EK>> for Result<T, E>
 where
     TK: Return,
@@ -105,21 +77,6 @@ where
         match self {
             Ok(val) => Ok(AsReturn::Ok(val.into_return()?)),
             Err(val) => Ok(AsReturn::Err(val.into_return()?)),
-        }
-    }
-}
-
-impl<T, TK, E, EK> IntoRespond<Mix<TK, EK>> for Result<T, E>
-where
-    TK: Kind,
-    T: IntoRespond<TK>,
-    EK: Kind,
-    E: IntoRespond<EK>,
-{
-    fn into_respond(self) -> OutputResult<AsRespond<TK, EK>> {
-        match self {
-            Ok(val) => Ok(AsRespond::Ok(val.into_respond()?)),
-            Err(val) => Ok(AsRespond::Err(val.into_respond()?)),
         }
     }
 }

--- a/src/output/deep/tuples.rs
+++ b/src/output/deep/tuples.rs
@@ -6,7 +6,6 @@ macro_rules! deep_tuples {
             impl<$($k: Kind),+> Kind for Deep<($($k),+,)>
             {
                 type Return = AsReturn<$($k),+,>;
-                type Respond = AsRespond<$($k),+,>;
             }
 
             impl<$($k: Return),+> Return for Deep<($($k),+,)>
@@ -17,7 +16,6 @@ macro_rules! deep_tuples {
             }
 
             pub struct AsReturn<$($k: Kind),+,>($($k::Return),+,);
-            pub struct AsRespond<$($k: Kind),+,>($($k::Respond),+,);
 
             impl<$($k),+> GetOutput for AsReturn<$($k),+,>
             where
@@ -27,17 +25,6 @@ macro_rules! deep_tuples {
 
                 fn output(&self) -> Option<Self::Output<'_>> {
                     Some(($(self.$i.output()?),+,))
-                }
-            }
-
-            impl<$($k),+> IntoOutput for AsRespond<$($k),+,>
-            where
-                $($k: Kind),+,
-            {
-                type Output<'u> = ($(<<$k as Kind>::Respond as IntoOutput>::Output<'u>),+,);
-
-                fn into_output(self, value_chain: &ValueChain) -> Self::Output<'_> {
-                    ($(self.$i.into_output(value_chain)),+,)
                 }
             }
 
@@ -60,16 +47,6 @@ macro_rules! deep_tuples {
             {
                 fn into_return(self) -> OutputResult<AsReturn<$($k),+,>> {
                     Ok(AsReturn($(self.$i.into_return()?),+,))
-                }
-            }
-
-            impl<$($k),+, $($t),+> IntoRespond<Deep<($($k),+,)>> for ($($t),+,)
-            where
-                $($k: Kind),+,
-                $($t: IntoRespond<$k>),+,
-            {
-                fn into_respond(self) -> OutputResult<AsRespond<$($k),+,>> {
-                    Ok(AsRespond($(self.$i.into_respond()?),+,))
                 }
             }
         }

--- a/src/output/deep/vec.rs
+++ b/src/output/deep/vec.rs
@@ -8,7 +8,6 @@ where
     K: Kind,
 {
     type Return = AsReturn<K>;
-    type Respond = AsRespond<K>;
 }
 
 impl<K> Return for Mix<K>
@@ -20,7 +19,6 @@ where
 }
 
 pub struct AsReturn<K: Kind>(Vec<K::Return>);
-pub struct AsRespond<K: Kind>(Vec<K::Respond>);
 
 impl<K> GetOutput for AsReturn<K>
 where
@@ -37,22 +35,6 @@ where
         }
 
         Some(out)
-    }
-}
-
-impl<K> IntoOutput for AsRespond<K>
-where
-    K: Kind,
-    Self: 'static,
-{
-    type Output<'u> = Vec<<<K as Kind>::Return as GetOutput>::Output<'u>>
-        where Self: 'u;
-
-    fn into_output(self, value_chain: &ValueChain) -> Self::Output<'_> {
-        self.0
-            .into_iter()
-            .map(|el| el.into_output(value_chain))
-            .collect()
     }
 }
 
@@ -81,20 +63,6 @@ where
         Ok(AsReturn(
             self.into_iter()
                 .map(|el| el.into_return())
-                .collect::<Result<_, _>>()?,
-        ))
-    }
-}
-
-impl<T, K> IntoRespond<Mix<K>> for Vec<T>
-where
-    K: Kind,
-    T: IntoRespond<K>,
-{
-    fn into_respond(self) -> OutputResult<AsRespond<K>> {
-        Ok(AsRespond(
-            self.into_iter()
-                .map(|el| el.into_respond())
                 .collect::<Result<_, _>>()?,
         ))
     }

--- a/src/output/lending.rs
+++ b/src/output/lending.rs
@@ -8,7 +8,6 @@ pub struct Lending<T: ?Sized + 'static>(core::marker::PhantomData<fn() -> T>);
 
 impl<T: ?Sized + 'static> Kind for Lending<T> {
     type Return = Lent<T>;
-    type Respond = Lent<T>;
 }
 
 impl<T: ?Sized + Send + Sync + 'static> Return for Lending<T> {
@@ -33,15 +32,6 @@ where
     }
 }
 
-impl<T0, T: ?Sized + 'static> IntoRespond<Lending<T>> for T0
-where
-    T0: Borrow<T> + Send + Sync + 'static,
-{
-    fn into_respond(self) -> OutputResult<Lent<T>> {
-        Ok(Lent(Box::new(self)))
-    }
-}
-
 pub struct Lent<T: ?Sized>(Box<dyn Borrow<T> + Send + Sync>);
 
 impl<T: ?Sized + 'static> GetOutput for Lent<T> {
@@ -51,16 +41,5 @@ impl<T: ?Sized + 'static> GetOutput for Lent<T> {
 
     fn output(&self) -> Option<Self::Output<'_>> {
         Some(self.0.as_ref().borrow())
-    }
-}
-
-impl<T: ?Sized + 'static> IntoOutput for Lent<T> {
-    type Output<'u> = &'u T
-        where
-            Self: 'u;
-
-    fn into_output(self, value_chain: &ValueChain) -> Self::Output<'_> {
-        let value = value_chain.add(self.0);
-        value.as_ref().borrow()
     }
 }

--- a/src/output/owning.rs
+++ b/src/output/owning.rs
@@ -6,7 +6,6 @@ pub struct Owning<T>(core::marker::PhantomData<fn() -> T>);
 
 impl<T: 'static> Kind for Owning<T> {
     type Return = Owned<T>;
-    type Respond = Owned<T>;
 }
 
 impl<T: 'static> Return for Owning<T> {
@@ -20,9 +19,9 @@ where
     #[cfg(any(feature = "std", feature = "spin-lock"))]
     fn into_return_once(self) -> OutputResult<Owned<T>> {
         let mutex = crate::private::MutexIsh::new(Some(self.into()));
-        Ok(Owned(Producer::Thunk(Box::new(move || {
+        Ok(Owned(Box::new(move || {
             mutex.locked(|option| option.take())
-        }))))
+        })))
     }
 
     #[cfg(not(any(feature = "std", feature = "spin-lock")))]
@@ -38,52 +37,22 @@ where
 {
     fn into_return(self) -> OutputResult<Owned<T>> {
         let value = self.into();
-        Ok(Owned(Producer::Thunk(Box::new(move || {
-            Some(value.clone())
-        }))))
+        Ok(Owned(Box::new(move || Some(value.clone()))))
     }
 }
 
 impl<T: Default + 'static> ReturnDefault<Owning<T>> for T {
     fn return_default() -> <Owning<T> as Kind>::Return {
-        Owned(Producer::Thunk(Box::new(|| Some(T::default()))))
+        Owned(Box::new(|| Some(T::default())))
     }
 }
 
-impl<T0, T: 'static> IntoRespond<Owning<T>> for T0
-where
-    T0: Into<T>,
-{
-    fn into_respond(self) -> OutputResult<Owned<T>> {
-        Ok(Owned(Producer::Value(self.into())))
-    }
-}
-
-pub struct Owned<T>(Producer<T>);
-
-enum Producer<T> {
-    Value(T),
-    Thunk(Box<dyn Fn() -> Option<T> + Send + Sync + 'static>),
-}
+pub struct Owned<T>(Box<dyn Fn() -> Option<T> + Send + Sync + 'static>);
 
 impl<T: 'static> GetOutput for Owned<T> {
     type Output<'u> = T where Self: 'u;
 
     fn output(&self) -> Option<Self::Output<'_>> {
-        match &self.0 {
-            Producer::Value(_) => None,
-            Producer::Thunk(thunk) => thunk(),
-        }
-    }
-}
-
-impl<T: 'static> IntoOutput for Owned<T> {
-    type Output<'u> = T where Self: 'u;
-
-    fn into_output(self, _value_chain: &ValueChain) -> Self::Output<'_> {
-        match self.0 {
-            Producer::Value(value) => value,
-            Producer::Thunk(thunk) => thunk().expect("thunk must return a value in IntoOutput"),
-        }
+        (*self.0)()
     }
 }

--- a/src/output/shallow/option.rs
+++ b/src/output/shallow/option.rs
@@ -8,7 +8,6 @@ type Response<T> = Option<Box<dyn Borrow<T> + Send + Sync>>;
 
 impl<T: ?Sized> Kind for Mix<T> {
     type Return = Response<T>;
-    type Respond = Response<T>;
 }
 
 impl<T: ?Sized> Return for Mix<T> {
@@ -22,16 +21,6 @@ impl<T: ?Sized + 'static> GetOutput for Response<T> {
 
     fn output(&self) -> Option<Self::Output<'_>> {
         Some(self.as_ref().map(|val| val.as_ref().borrow()))
-    }
-}
-
-impl<T: ?Sized + 'static> IntoOutput for Response<T> {
-    type Output<'u> = Option<&'u T>
-        where
-            Self: 'u;
-
-    fn into_output(self, value_chain: &ValueChain) -> Self::Output<'_> {
-        self.map(|val| value_chain.add(val).as_ref().borrow())
     }
 }
 
@@ -53,4 +42,3 @@ macro_rules! into {
 
 into!(IntoReturnOnce, into_return_once);
 into!(IntoReturn, into_return);
-into!(IntoRespond, into_respond);

--- a/src/output/shallow/result.rs
+++ b/src/output/shallow/result.rs
@@ -10,7 +10,6 @@ type Response<T, E> = Result<Box<dyn Borrow<T> + Send + Sync>, Owned<E>>;
 
 impl<T: ?Sized, E: 'static> Kind for Mix<T, E> {
     type Return = Response<T, E>;
-    type Respond = Response<T, E>;
 }
 
 impl<T: ?Sized, E: 'static> Return for Mix<T, E>
@@ -33,19 +32,6 @@ impl<T: ?Sized + 'static, E: 'static> GetOutput for Response<T, E> {
     }
 }
 
-impl<T: ?Sized + 'static, E: 'static> IntoOutput for Response<T, E> {
-    type Output<'u> = Result<&'u T, E>
-        where
-            Self: 'u;
-
-    fn into_output(self, value_chain: &ValueChain) -> Self::Output<'_> {
-        match self {
-            Ok(val) => Ok(value_chain.add(val).as_ref().borrow()),
-            Err(err) => Err(err.into_output(value_chain)),
-        }
-    }
-}
-
 macro_rules! into {
     ($trait:ident, $method:ident) => {
         impl<T0, T: ?Sized + 'static, E0, E: 'static> $trait<Mix<T, E>> for Result<T0, E0>
@@ -65,4 +51,3 @@ macro_rules! into {
 
 into!(IntoReturnOnce, into_return_once);
 into!(IntoReturn, into_return);
-into!(IntoRespond, into_respond);

--- a/src/output/shallow/vec.rs
+++ b/src/output/shallow/vec.rs
@@ -11,7 +11,6 @@ type Response<T> = Vec<Box<dyn Borrow<T> + Send + Sync>>;
 
 impl<T: ?Sized> Kind for Mix<T> {
     type Return = Response<T>;
-    type Respond = Response<T>;
 }
 
 impl<T: ?Sized + 'static> GetOutput for Response<T> {
@@ -21,18 +20,6 @@ impl<T: ?Sized + 'static> GetOutput for Response<T> {
 
     fn output(&self) -> Option<Self::Output<'_>> {
         Some(self.iter().map(|el| el.as_ref().borrow()).collect())
-    }
-}
-
-impl<T: ?Sized + 'static> IntoOutput for Response<T> {
-    type Output<'u> = Vec<&'u T>
-        where
-            Self: 'u;
-
-    fn into_output(self, value_chain: &ValueChain) -> Self::Output<'_> {
-        self.into_iter()
-            .map(|el| value_chain.add(el).as_ref().borrow())
-            .collect()
     }
 }
 
@@ -54,4 +41,3 @@ macro_rules! into {
 
 into!(IntoReturnOnce, into_return_once);
 into!(IntoReturn, into_return);
-into!(IntoRespond, into_respond);

--- a/src/output/static_ref.rs
+++ b/src/output/static_ref.rs
@@ -5,7 +5,6 @@ pub struct StaticRef<T: ?Sized>(core::marker::PhantomData<fn() -> T>);
 
 impl<T: ?Sized + Send + Sync + 'static> Kind for StaticRef<T> {
     type Return = Reference<T>;
-    type Respond = Reference<T>;
 }
 
 impl<T: ?Sized + Send + Sync + 'static> Return for StaticRef<T> {
@@ -24,12 +23,6 @@ impl<T: ?Sized + Send + Sync + 'static> IntoReturn<StaticRef<T>> for &'static T 
     }
 }
 
-impl<T: ?Sized + Send + Sync + 'static> IntoRespond<StaticRef<T>> for &'static T {
-    fn into_respond(self) -> OutputResult<Reference<T>> {
-        Ok(Reference(self))
-    }
-}
-
 pub struct Reference<T: ?Sized + 'static>(pub(crate) &'static T);
 
 impl<T: ?Sized + Send + Sync + 'static> GetOutput for Reference<T> {
@@ -37,13 +30,5 @@ impl<T: ?Sized + Send + Sync + 'static> GetOutput for Reference<T> {
 
     fn output(&self) -> Option<Self::Output<'_>> {
         Some(self.0)
-    }
-}
-
-impl<T: ?Sized + Send + Sync + 'static> IntoOutput for Reference<T> {
-    type Output<'u> = &'static T;
-
-    fn into_output(self, _value_chain: &ValueChain) -> Self::Output<'_> {
-        self.0
     }
 }

--- a/tests/it/arg_borrows.rs
+++ b/tests/it/arg_borrows.rs
@@ -1,0 +1,17 @@
+use unimock::*;
+
+#[unimock(api=TraitMock)]
+trait Trait {
+    fn arg_borrow<'a>(&self, s: &'a str) -> &'a str;
+}
+
+#[test]
+fn arg_borrows() {
+    let u = Unimock::new(
+        TraitMock::arg_borrow
+            .next_call(matching!())
+            .answers(&|_, s| &s[1..]),
+    );
+
+    assert_eq!("bc", u.arg_borrow("abc"));
+}

--- a/tests/it/default_impl.rs
+++ b/tests/it/default_impl.rs
@@ -30,7 +30,7 @@ mod default_impl_borrowed {
             Unimock::new(
                 DefaultBodyMock::default_body
                     .next_call(matching!(21))
-                    .applies(&|_| respond(777))
+                    .answers(&|_, _| 777)
             )
             .default_body(21)
         );
@@ -43,7 +43,7 @@ mod default_impl_borrowed {
             Unimock::new(
                 DefaultBodyMock::core
                     .next_call(matching!(42))
-                    .applies(&|_| respond(666))
+                    .answers(&|_, _| 666)
             )
             .default_body(21)
         );
@@ -69,7 +69,7 @@ mod default_impl_mut {
             Unimock::new(
                 MutDefaultBodyMock::default_body
                     .next_call(matching!(21))
-                    .applies(&|_arg| respond(777))
+                    .answers(&|_, _arg| 777)
             )
             .default_body(21)
         );
@@ -82,7 +82,7 @@ mod default_impl_mut {
             Unimock::new(
                 MutDefaultBodyMock::core
                     .next_call(matching!(42))
-                    .applies(&|_| respond(666))
+                    .answers(&|_, _| 666)
             )
             .default_body(21)
         );
@@ -105,7 +105,7 @@ mod default_impl_mut {
             Unimock::new(
                 MutDefaultBodyBorrowMock::borrow_ret
                     .next_call(matching!(42))
-                    .applies(&|_| respond(666))
+                    .answers(&|_, _| &666)
             )
             .default_borrow_ret(21)
         );
@@ -133,7 +133,7 @@ mod default_impl_rc {
             Rc::new(Unimock::new(
                 DefaultBodyMock::default_body
                     .next_call(matching!(21))
-                    .applies(&|_| respond(777))
+                    .answers(&|_, _| 777)
             ))
             .default_body(21)
         );
@@ -161,7 +161,7 @@ mod default_impl_arc {
             Arc::new(Unimock::new(
                 DefaultBodyMock::default_body
                     .next_call(matching!(21))
-                    .applies(&|_| respond(777))
+                    .answers(&|_, _| 777)
             ))
             .default_body(21)
         );
@@ -256,7 +256,7 @@ mod default_impl_pin {
         let mut unimock = Unimock::new(
             PinDefault1Mock::pinned
                 .next_call(matching!(123))
-                .applies(&|_| respond(666)),
+                .answers(&|_, _| &666),
         );
         assert_eq!(
             &666,

--- a/tests/it/generic.rs
+++ b/tests/it/generic.rs
@@ -334,9 +334,8 @@ mod issue_37_mutation_with_generics {
         MockMock::func
             .with_types::<()>()
             .next_call(matching!())
-            .applies(&|_, foo| {
+            .answers(&|_, _, foo| {
                 foo.baz += 1;
-                respond(())
             });
     }
 }

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -9,6 +9,8 @@ use core::future::Future;
 #[cfg(any(feature = "std", feature = "spin-lock"))]
 mod basic;
 
+mod arg_borrows;
+
 mod default_impl;
 mod errors;
 mod generic;

--- a/tests/it/std.rs
+++ b/tests/it/std.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::write_literal)]
+#![allow(clippy::to_string_in_format_args)]
 
 use std::io::{BufRead, BufReader, Write};
 
@@ -17,7 +18,7 @@ fn test_display() {
         Unimock::new(
             DisplayMock::fmt
                 .next_call(matching!(_))
-                .applies(&|f| respond(write!(f, "u")))
+                .answers(&|_, f| write!(f, "u"))
         )
         .to_string()
     );
@@ -39,7 +40,7 @@ fn test_debug() {
     let unimock = Unimock::new(
         DebugMock::fmt
             .next_call(matching!())
-            .applies(&|f| respond(write!(f, "u"))),
+            .answers(&|_, f| write!(f, "u")),
     );
 
     assert_eq!("u", format!("{unimock:?}"));
@@ -50,10 +51,10 @@ fn test_read() {
     let mut reader = BufReader::new(Unimock::new((
         ReadMock::read
             .next_call(matching!(_))
-            .applies(&|mut f| respond(f.write(b"ok"))),
+            .answers(&|_, mut f| f.write(b"ok")),
         ReadMock::read
             .next_call(matching!(_))
-            .applies(&|mut f| respond(f.write(b"\n"))),
+            .answers(&|_, mut f| f.write(b"\n")),
     )));
 
     let mut line = String::new();
@@ -95,7 +96,7 @@ fn test_fmt_io_duplex_default_impl_implicit() {
     let unimock = Unimock::new((
         DisplayMock::fmt
             .next_call(matching!())
-            .applies(&|f| respond(write!(f, "hello {}", "unimock".to_string()))),
+            .answers(&|_, f| write!(f, "hello {}", "unimock".to_string())),
         // NOTE: write! calls `write_all` which should get re-routed to `write`:
         WriteMock::write
             .next_call(matching!(eq!(b"hello ")))
@@ -115,7 +116,7 @@ fn test_fmt_io_duplex_default_impl_explicit() {
     let unimock = Unimock::new((
         DisplayMock::fmt
             .next_call(matching!())
-            .applies(&|f| respond(write!(f, "hello {}", "unimock".to_string()))),
+            .answers(&|_, f| write!(f, "hello {}", "unimock".to_string())),
         WriteMock::write_all
             .next_call(matching!(eq!(b"hello ")))
             .applies_default_impl(),

--- a/tests/it/test_mock_tokio.rs
+++ b/tests/it/test_mock_tokio.rs
@@ -12,19 +12,18 @@ fn test_tokio_read() {
         let mut u = Unimock::new((
             AsyncReadMock::poll_read
                 .next_call(matching!())
-                .applies(&|_, buf| {
+                .answers(&|_, _, buf| {
                     buf.put_slice(&[1, 2, 3]);
 
                     // Can return Poll::Ready explicitly.
-                    respond(Poll::Ready(Ok(())))
+                    Poll::Ready(Ok(()))
                 }),
             AsyncReadMock::poll_read
                 .next_call(matching!())
-                .applies(&|_, buf| {
+                .answers(&|_, _, buf| {
                     buf.put_slice(&[5, 6, 7]);
 
-                    // Also can return just Ok(()) because of `impl From<T> for Poll<T>`
-                    respond(Ok(()))
+                    Ok(()).into()
                 }),
         ));
         let mut buf = [0; 10];
@@ -33,7 +32,7 @@ fn test_tokio_read() {
         assert_eq!(n, 3);
         assert_eq!(&buf[0..n], &[1, 2, 3]);
 
-        u.read(&mut buf).await.unwrap();
+        let _ = u.read(&mut buf).await.unwrap();
     }
     .test()
 }

--- a/unimock_macros/src/unimock/answer_fn.rs
+++ b/unimock_macros/src/unimock/answer_fn.rs
@@ -1,0 +1,134 @@
+use std::collections::BTreeSet;
+
+use quote::quote;
+
+use crate::unimock::util::{
+    guess_is_pin, register_lifetimes_and_substitute_missing, rename_lifetimes, self_type_to_unimock,
+};
+
+use super::{method::MockMethod, trait_info::TraitInfo, Attr};
+
+pub fn make_answer_fn(
+    method: &MockMethod,
+    trait_info: &TraitInfo,
+    attr: &Attr,
+) -> proc_macro2::TokenStream {
+    let prefix = &attr.prefix;
+
+    let mut hrtbs: BTreeSet<syn::Lifetime> = Default::default();
+
+    let self_lifetime = syn::Lifetime::new("'__u", proc_macro2::Span::call_site());
+
+    for lifetime_param in method.adapted_sig.generics.lifetimes() {
+        hrtbs.insert(lifetime_param.lifetime.clone());
+    }
+
+    let mut args: syn::punctuated::Punctuated<syn::Type, syn::token::Comma> = Default::default();
+
+    for fn_arg in &method.adapted_sig.inputs {
+        match fn_arg {
+            syn::FnArg::Receiver(syn::Receiver {
+                reference,
+                mutability,
+                ty,
+                ..
+            }) => {
+                if let Some((_, lifetime)) = reference {
+                    let lifetime = match lifetime {
+                        Some(lifetime) => {
+                            hrtbs.insert(lifetime.clone());
+                            lifetime.clone()
+                        }
+                        None => {
+                            hrtbs.insert(self_lifetime.clone());
+                            self_lifetime.clone()
+                        }
+                    };
+
+                    args.push(syn::Type::Reference(syn::TypeReference {
+                        and_token: Default::default(),
+                        lifetime: Some(lifetime),
+                        mutability: *mutability,
+                        elem: syn::parse_quote! {
+                            #prefix::Unimock
+                        },
+                    }));
+                } else if guess_is_pin(ty) {
+                    hrtbs.insert(self_lifetime.clone());
+                    let ty = syn::parse_quote! { & #self_lifetime mut #prefix::Unimock };
+                    args.push(ty);
+                } else {
+                    let ty = register_lifetimes_and_substitute_missing(
+                        ty.as_ref().clone(),
+                        Some(&self_lifetime),
+                        &mut hrtbs,
+                    );
+                    let receiver = self_type_to_unimock(ty, trait_info, attr);
+
+                    args.push(receiver);
+                }
+            }
+            syn::FnArg::Typed(syn::PatType { pat, ty, .. }) => match pat.as_ref() {
+                syn::Pat::Ident(ident) if ident.ident == "self" => {
+                    if guess_is_pin(ty) {
+                        hrtbs.insert(self_lifetime.clone());
+                        let ty = syn::parse_quote! { & #self_lifetime mut #prefix::Unimock };
+                        args.push(ty);
+                    } else {
+                        let ty = register_lifetimes_and_substitute_missing(
+                            ty.as_ref().clone(),
+                            Some(&self_lifetime),
+                            &mut hrtbs,
+                        );
+                        let ty = self_type_to_unimock(ty, trait_info, attr);
+                        args.push(ty);
+                    }
+                }
+                _ => {
+                    let ty = register_lifetimes_and_substitute_missing(
+                        ty.as_ref().clone(),
+                        None,
+                        &mut hrtbs,
+                    );
+                    let ty = self_type_to_unimock(ty, trait_info, attr);
+
+                    args.push(ty);
+                }
+            },
+        }
+    }
+
+    let arrow_output = if let Some(mut ty) = method.output_structure.output_type_stripped() {
+        rename_lifetimes(&mut ty, &mut |lifetime| match lifetime {
+            Some(lifetime) => {
+                if hrtbs.contains(lifetime) {
+                    None
+                } else {
+                    Some("'static".into())
+                }
+            }
+            None => Some(self_lifetime.to_string().into()),
+        });
+        let ty = self_type_to_unimock(ty, trait_info, attr);
+        Some(quote! { -> #ty })
+    } else {
+        None
+    };
+
+    let hrtb = if hrtbs.is_empty() {
+        quote!()
+    } else {
+        let mut punctuated: syn::punctuated::Punctuated<syn::Lifetime, syn::token::Comma> =
+            Default::default();
+        for lifetime in hrtbs {
+            if lifetime.ident != "static" {
+                punctuated.push(lifetime);
+            }
+        }
+        quote! { for<#punctuated> }
+    };
+
+    quote! {
+        dyn (#hrtb Fn(#args) #arrow_output) + Send + Sync
+    }
+}


### PR DESCRIPTION
I tried as a test to dog-food the `applies` API introduced in https://github.com/audunhalland/unimock/pull/43, but found I didn't like it very much. This change brings back the `answers` API, but without any type magic around its return type, so the `respond` API has been completely removed. The type returned through `AnswerFn` is just the same raw type that the trait method returns, and the signature is almost the same. Borrows can be made by using new method `Unimock::make_ref`.