### PR TITLE
fix: Basic support for mutable output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- Basic support for mutable outputs ([#49](https://github.com/audunhalland/unimock/pull/49))
 
 ## [0.6.2] - 2024-03-27
 ### Fixed

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -869,6 +869,13 @@ impl Unimock {
         self.value_chain.add(value)
     }
 
+    /// Convert the given value into a mutable reference.
+    ///
+    /// This can be useful when returning mutable references from `answers` functions.
+    pub fn make_mut<T: Send + Sync + 'static>(&mut self, value: T) -> &mut T {
+        self.value_chain.add_mut(value)
+    }
+
     #[track_caller]
     fn from_assembler(
         assembler_result: Result<MockAssembler, alloc::String>,

--- a/src/output.rs
+++ b/src/output.rs
@@ -4,6 +4,7 @@ use crate::alloc::Box;
 
 pub(crate) mod deep;
 pub(crate) mod lending;
+pub(crate) mod mut_lending;
 pub(crate) mod owning;
 pub(crate) mod shallow;
 pub(crate) mod static_ref;
@@ -59,8 +60,12 @@ pub trait ReturnDefault<K: Kind> {
     fn return_default() -> K::Return;
 }
 
+/// A "marker" for mutable types
+pub struct Mutable<T>(pub(crate) T);
+
 pub use deep::Deep;
 pub use lending::Lending;
+pub use mut_lending::MutLending;
 pub use owning::Owning;
 pub use shallow::Shallow;
 pub use static_ref::StaticRef;

--- a/src/output/mut_lending.rs
+++ b/src/output/mut_lending.rs
@@ -1,0 +1,23 @@
+use core::marker::PhantomData;
+
+use super::*;
+
+/// A type category for values lent out by Unimock.
+#[doc(hidden)]
+pub struct MutLending<T: ?Sized + 'static>(core::marker::PhantomData<fn() -> T>);
+
+impl<T: ?Sized + 'static> Kind for MutLending<T> {
+    type Return = MutLent<T>;
+}
+
+pub struct MutLent<T: ?Sized>(PhantomData<T>);
+
+impl<T: ?Sized + 'static> GetOutput for MutLent<T> {
+    type Output<'u> = &'u mut T
+        where
+            Self: 'u;
+
+    fn output(&self) -> Option<Self::Output<'_>> {
+        None
+    }
+}

--- a/src/output/shallow/result.rs
+++ b/src/output/shallow/result.rs
@@ -4,22 +4,28 @@ use core::borrow::Borrow;
 
 use crate::output::{owning::Owned, *};
 
-type Mix<T, E> = Shallow<Result<&'static T, E>>;
+type Ref<T, E> = Shallow<Result<&'static T, E>>;
+type Mut<T, E> = Shallow<Result<&'static mut T, E>>;
 
-type Response<T, E> = Result<Box<dyn Borrow<T> + Send + Sync>, Owned<E>>;
+type RefResponse<T, E> = Result<Box<dyn Borrow<T> + Send + Sync>, Owned<E>>;
+type MutResponse<T, E> = Result<Mutable<Box<dyn Borrow<T> + Send + Sync>>, Owned<E>>;
 
-impl<T: ?Sized, E: 'static> Kind for Mix<T, E> {
-    type Return = Response<T, E>;
+impl<T: ?Sized, E: 'static> Kind for Ref<T, E> {
+    type Return = RefResponse<T, E>;
 }
 
-impl<T: ?Sized, E: 'static> Return for Mix<T, E>
+impl<T: ?Sized, E: 'static> Kind for Mut<T, E> {
+    type Return = MutResponse<T, E>;
+}
+
+impl<T: ?Sized, E: 'static> Return for Ref<T, E>
 where
     Owning<E>: Return,
 {
     type Type = Result<Box<dyn Borrow<T> + Send + Sync>, <Owning<E> as Return>::Type>;
 }
 
-impl<T: ?Sized + 'static, E: 'static> GetOutput for Response<T, E> {
+impl<T: ?Sized + 'static, E: 'static> GetOutput for RefResponse<T, E> {
     type Output<'u> = Result<&'u T, E>
         where
             Self: 'u;
@@ -32,14 +38,27 @@ impl<T: ?Sized + 'static, E: 'static> GetOutput for Response<T, E> {
     }
 }
 
+impl<T: ?Sized + 'static, E: 'static> GetOutput for MutResponse<T, E> {
+    type Output<'u> = Result<&'u mut T, E>
+        where
+            Self: 'u;
+
+    fn output(&self) -> Option<Self::Output<'_>> {
+        match self {
+            Ok(_) => None,
+            Err(err) => Some(Err(err.output()?)),
+        }
+    }
+}
+
 macro_rules! into {
     ($trait:ident, $method:ident) => {
-        impl<T0, T: ?Sized + 'static, E0, E: 'static> $trait<Mix<T, E>> for Result<T0, E0>
+        impl<T0, T: ?Sized + 'static, E0, E: 'static> $trait<Ref<T, E>> for Result<T0, E0>
         where
             T0: Borrow<T> + Send + Sync + 'static,
             E0: $trait<Owning<E>>,
         {
-            fn $method(self) -> OutputResult<Response<T, E>> {
+            fn $method(self) -> OutputResult<RefResponse<T, E>> {
                 Ok(match self {
                     Ok(val) => Ok(Box::new(val)),
                     Err(err) => Err(err.$method()?),

--- a/tests/it/basic.rs
+++ b/tests/it/basic.rs
@@ -1193,3 +1193,39 @@ mod apply_fn {
         assert_eq!(1, b);
     }
 }
+
+mod mut_output {
+    use unimock::*;
+
+    #[unimock(api = TraitMock)]
+    trait Trait {
+        fn ref_mut(&mut self) -> &mut i32;
+        fn option_mut(&mut self) -> Option<&mut i32>;
+        fn result_mut(&mut self) -> Result<&mut i32, ()>;
+    }
+
+    #[test]
+    fn test_ref_mut() {
+        let mut u = Unimock::new(
+            TraitMock::ref_mut
+                .next_call(matching!())
+                .answers(&|u| u.make_mut(42)),
+        );
+
+        let num = u.ref_mut();
+        *num += 1;
+    }
+
+    #[test]
+    fn test_option_mut() {
+        let mut u = Unimock::new(
+            TraitMock::option_mut
+                .next_call(matching!())
+                .answers(&|u| Some(u.make_mut(42))),
+        );
+
+        if let Some(num) = u.option_mut() {
+            *num += 1;
+        }
+    }
+}


### PR DESCRIPTION
Support for mutable reference output, either as `&'_ mut T`, `Option<&'_ mut T>` or `Result<&'_ mut T, E>`.

These values cannot be constructed using `.returns` (it won't compile because `trait Return` is not implemented for the new output kind). But they can be constructed within the `AnswerFn` by calling `Unimock::make_mut`.

The `T` also needs to be `Send` and `Sync` because that value needs to be owned by Unimock, and Unimock itself needs to be `Send` and `Sync` to be maximally usable.

fixes #48